### PR TITLE
Use Conda Env for git for Quick Builds

### DIFF
--- a/templates/Quick.dockerfile.j2
+++ b/templates/Quick.dockerfile.j2
@@ -16,9 +16,10 @@ FROM rapidsaistaging/rapidsai-dev-nightly-staging:{{ RAPIDS_VERSION }}-cuda${CUD
 ARG PARALLEL_LEVEL
 
 {# Update RAPIDS repos #}
+RUN source activate rapids && \
 {% for lib in RAPIDS_LIBS %}
-RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
-    git pull
+    cd ${RAPIDS_DIR}/{{ lib.name }} && \
+    git pull {{ " \\" if not loop.last }}
 {% endfor %}
 
 {# Build RAPIDS #}


### PR DESCRIPTION
The `devel-quick` build [Jenkins job](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel-quick-build/) has been failing over the past few days to due no `git` command found (see screenshot). This is likely due to the recent changes in parent images, but regardless we should probably use the conda environment here so that the version of `git` used in `quick` builds is the same as other builds.

![image](https://user-images.githubusercontent.com/7400326/84416541-5aa5df00-abe2-11ea-8b42-0cfca8dff382.png)
