### PR TITLE
devel-quick fix

### DIFF
--- a/templates/Quick.dockerfile.j2
+++ b/templates/Quick.dockerfile.j2
@@ -19,7 +19,7 @@ ARG PARALLEL_LEVEL
 RUN source activate rapids && \
 {% for lib in RAPIDS_LIBS %}
     cd ${RAPIDS_DIR}/{{ lib.name }} && \
-    git pull {{ " \\" if not loop.last }}
+    git pull {{ "&& \\" if not loop.last }}
 {% endfor %}
 
 {# Build RAPIDS #}


### PR DESCRIPTION
This PR fixes the `devel-quick` templates. It adds the missing `&&` that's necessary for multiple commands to be run in a single `RUN` step.