### PR TITLE
Workflow updates

### DIFF
--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -1,32 +1,18 @@
-name: Update Dockerfiles on Default Branch Merge
+name: Validate generated-dockerfiles
 
-on:
-  pull_request:
-    types: [closed]
+on: pull_request
 
 jobs:
   update-dockerfiles:
-    name: Update Dockerfiles on Default Branch Merge
+    name: Dockerfiles up-to-date
     runs-on: ubuntu-latest
     container: python:3.8
-    if: github.event.pull_request.base.ref == github.event.repository.default_branch && github.event.pull_request.merged == true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.1.1
+        uses: actions/checkout@v2
       - name: Generate new Dockerfiles
         run: |
-          rm -rf generated-dockerfiles/*.Dockerfile
-          pip install Jinja2 PyYAML
-          python generate_dockerfiles.py
-          mv build/* generated-dockerfiles/
-      - name: Setup git Config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-      - name: Commit to Repository (if there are changes)
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          git add generated-dockerfiles/*
-          git commit -m "[GH Actions] Generate Dockerfiles for PR $PR_NUMBER" || echo 'no changes to commit'
-          git push
+          pip install -r requirements.txt
+          ./generate_dockerfiles.py
+      - name: Check diffs
+        run: git diff --exit-code --quiet

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vscode
-build
 
 
 # Created by https://www.gitignore.io/api/macos,linux

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+repos:
+  - repo: local
+    hooks:
+      - id: generate-dockerfiles
+        name: Generate Dockerfiles
+        language: script
+        entry: generate_dockerfiles.py
+        pass_filenames: no
+        always_run: yes
+        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,8 @@ repos:
   - repo: local
     hooks:
       - id: generate-dockerfiles
-        name: Generate Dockerfiles
+        name: Dockerfiles updated?
         language: script
         entry: generate_dockerfiles.py
         pass_filenames: no
         always_run: yes
-        verbose: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,11 @@ python generate_dockerfiles.py
 ./generate_dockerfiles.py
 ```
 
-`generate_dockerfiles.py` will write files to a `build` directory only if they don't exist already _or_ if they've changed since the last time the script was run. This helps to identify the impact of changes made to the `templates/` directory.
+This will write the Dockerfiles to the `generated-dockerfiles` directory.
 
 ## Building the Docker Images
 
-See the [_Building Images_](README.md#Building-Images) section in the `README.md` for details on how to build the compiled Dockerfiles. Replace the `generated-dockerfiles` folder with the `build` folder to build images compiled locally.
+See the [_Building Images_](README.md#Building-Images) section in the `README.md` for details on how to build the compiled Dockerfiles.
 
 ## Adding a new Repo to Devel Images
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ This repo uses [Jinja2](https://www.palletsprojects.com/p/jinja/) to generate Do
 - [Project Structure](#Project-Structure)
 - [Development](#Development)
 - [Building the Docker Images](#Building-the-Docker-Images)
+- [CI](#CI)
+- [Pre-Commit Hook](#Pre-commit-hook)
 - [Adding a new Repo to Devel Images](#Adding-a-new-Repo-to-Devel-Images)
 - [Recommended VS Code Plugin](#Recommended-VS-Code-Plugin)
 
@@ -54,6 +56,16 @@ This will write the Dockerfiles to the `generated-dockerfiles` directory.
 ## Building the Docker Images
 
 See the [_Building Images_](README.md#Building-Images) section in the `README.md` for details on how to build the compiled Dockerfiles.
+
+## CI
+
+The following CI checks must pass before a PR can be merged:
+
+- **Dockerfiles updated** - the Dockerfiles in `generated-dockerfiles` must be up to date. Make sure to have run and committed the files that are output from `generate_dockerfiles.py` to ensure this check passes. See the [Pre-commit Hook](#Pre-commit-Hook) section below to get earlier feedback.
+
+## Pre-commit Hook
+
+This repo utilizes [pre-commit](https://pre-commit.com/) to provide developers quick feedback about their changes. Install [pre-commit](https://pre-commit.com/#installation) and run `pre-commit install` from the project's root folder to activate the hooks.
 
 ## Adding a new Repo to Devel Images
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ The following CI checks must pass before a PR can be merged:
 
 ## Pre-commit Hook
 
-This repo utilizes [pre-commit](https://pre-commit.com/) to provide developers quick feedback about their changes. Install [pre-commit](https://pre-commit.com/#installation) and run `pre-commit install` from the project's root folder to activate the hooks.
+This repo utilizes [pre-commit](https://pre-commit.com/) to provide developers with quick feedback about their changes. Install [pre-commit](https://pre-commit.com/#installation) and run `pre-commit install` from the project's root folder to activate the hooks.
 
 ## Adding a new Repo to Devel Images
 


### PR DESCRIPTION
This PR updates the workflow for the `docker` repo to reflect the following changes:

- The `generate_dockerfiles.py` script now writes Dockerfiles directly to `generated-dockerfiles/`.
- The existing GitHub action has been modified to validate that the files in `generated-dockerfiles/` are up-to-date before a PR can be merged. This means users will be responsible for running this whenever changes are introduced.
- A `.pre-commit-config.yaml` file has been introduced so that devs can opt-in to using [pre-commit](https://pre-commit.com/) hooks to automatically generate the latest Dockerfiles during commits.

The result of these changes is that reviewers will now be able to see how changes in the `templates/` directory affect the final Dockerfiles in PRs. Using the GitHub Action and pre-commit hook ensures that the `generated-dockerfiles` folder is still always up to date.