### PR TITLE
Fix devel typo

### DIFF
--- a/ci/axis/devel.yaml
+++ b/ci/axis/devel.yaml
@@ -1,6 +1,6 @@
 BUILD_IMAGE:
   - rapidsai/rapidsai-dev
-  - rapidsai/rapidsai-dev-nighlty
+  - rapidsai/rapidsai-dev-nightly
 
 FROM_IMAGE:
   - gpuci/rapidsai


### PR DESCRIPTION
This PR fixes a typo that we must have all overlooked.

We'll also have to delete the below DockerHub repo that was created as a result and re-publish the latest nightlies.

 https://hub.docker.com/r/rapidsai/rapidsai-dev-nighlty/tags