### PR TITLE
FIX Install RAPIDS in `runtime` containers

### DIFF
--- a/generated-dockerfiles/centos7-base.Dockerfile
+++ b/generated-dockerfiles/centos7-base.Dockerfile
@@ -29,7 +29,7 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
   rapids=${RAPIDS_VER} 
 
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -46,7 +46,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -23,6 +23,9 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
+RUN gpuci_retry conda install -y -n rapids \
+  rapids=${RAPIDS_VER}
+
 
 RUN gpuci_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -23,11 +23,11 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
   rapids=${RAPIDS_VER}
 
 
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/generated-dockerfiles/ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-base.Dockerfile
@@ -29,7 +29,7 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
   rapids=${RAPIDS_VER} 
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -49,7 +49,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -23,6 +23,9 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
+RUN gpuci_retry conda install -y -n rapids \
+  rapids=${RAPIDS_VER}
+
 
 RUN gpuci_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -23,11 +23,11 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
   rapids=${RAPIDS_VER}
 
 
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/templates/Base.dockerfile.j2
+++ b/templates/Base.dockerfile.j2
@@ -33,7 +33,7 @@ COPY libm.so.6 ${GCC7_DIR}/lib64
 
 {% include 'partials/env_debug.dockerfile.j2' %}
 
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
   rapids=${RAPIDS_VER} 
 
 {# Cleaup conda and set ACLs for all users #}

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -21,7 +21,7 @@ ARG RAPIDS_VER={{ RAPIDS_VERSION }}*
 {# Install the notebook dependencies and the notebook repo #}
 {% include 'partials/env_debug.dockerfile.j2' %}
 
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
   rapids=${RAPIDS_VER}
 
 {% include 'partials/install_notebooks.dockerfile.j2' %}

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -21,6 +21,9 @@ ARG RAPIDS_VER={{ RAPIDS_VERSION }}*
 {# Install the notebook dependencies and the notebook repo #}
 {% include 'partials/env_debug.dockerfile.j2' %}
 
+RUN gpuci_retry conda install -y -n rapids \
+  rapids=${RAPIDS_VER}
+
 {% include 'partials/install_notebooks.dockerfile.j2' %}
 
 {# Cleaup conda and set ACLs for all users #}

--- a/templates/partials/install_notebooks.dockerfile.j2
+++ b/templates/partials/install_notebooks.dockerfile.j2
@@ -1,7 +1,7 @@
 {# This partial is used to install notebooks and their deps into 'runtime' and 'devel' images #}
 
 {# Install the rapids-notebook-env meta-pkg #}
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry conda install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}


### PR DESCRIPTION
Previously `runtime` containers FROM-ed `base` where RAPIDS was already installed. The changes made to the build process broke that dependency so we have to install RAPIDS in `runtime` separately.

This is related to an issue that was reported where `import cuml` does not work in `runtime` images. The output from `conda list` does not show `cuml` or any RAPIDS packages are installed with the current `runtime` images. The change in this PR installs RAPIDS to fix this issue.