### PR TITLE
FIX Remove duplicate conda command

### DIFF
--- a/generated-dockerfiles/centos7-base.Dockerfile
+++ b/generated-dockerfiles/centos7-base.Dockerfile
@@ -29,7 +29,7 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
   rapids=${RAPIDS_VER} 
 
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -46,7 +46,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -23,11 +23,11 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
   rapids=${RAPIDS_VER}
 
 
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/generated-dockerfiles/ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-base.Dockerfile
@@ -29,7 +29,7 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
   rapids=${RAPIDS_VER} 
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -49,7 +49,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -23,11 +23,11 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
   rapids=${RAPIDS_VER}
 
 
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}

--- a/templates/Base.dockerfile.j2
+++ b/templates/Base.dockerfile.j2
@@ -33,7 +33,7 @@ COPY libm.so.6 ${GCC7_DIR}/lib64
 
 {% include 'partials/env_debug.dockerfile.j2' %}
 
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
   rapids=${RAPIDS_VER} 
 
 {# Cleaup conda and set ACLs for all users #}

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -21,7 +21,7 @@ ARG RAPIDS_VER={{ RAPIDS_VERSION }}*
 {# Install the notebook dependencies and the notebook repo #}
 {% include 'partials/env_debug.dockerfile.j2' %}
 
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
   rapids=${RAPIDS_VER}
 
 {% include 'partials/install_notebooks.dockerfile.j2' %}

--- a/templates/partials/install_notebooks.dockerfile.j2
+++ b/templates/partials/install_notebooks.dockerfile.j2
@@ -1,7 +1,7 @@
 {# This partial is used to install notebooks and their deps into 'runtime' and 'devel' images #}
 
 {# Install the rapids-notebook-env meta-pkg #}
-RUN gpuci_conda_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}


### PR DESCRIPTION
`gpuci_conda_retry` already has the `conda` command - so calling `gpuci_conda_retry conda` results in an error of `conda conda` not defined. This removes the extra `conda` defs leaving only `gpuci_conda_retry`