### PR TITLE
FIX Add utils and make `/rapids` dir

### DIFF
--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -17,6 +17,13 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER=0.15*
 
+ENV RAPIDS_DIR=/rapids
+
+RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC7_DIR}/lib64
+COPY start_jupyter.sh nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
+
+COPY libm.so.6 ${GCC7_DIR}/lib64
+
 
 RUN source activate rapids \
   && env \

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -17,6 +17,13 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER=0.15*
 
+ENV RAPIDS_DIR=/rapids
+ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
+
+RUN mkdir -p ${RAPIDS_DIR}/utils 
+COPY start_jupyter.sh nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
+
+
 
 RUN source activate rapids \
   && env \

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -18,6 +18,20 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER={{ RAPIDS_VERSION }}*
 
+ENV RAPIDS_DIR=/rapids
+{% if "ubuntu" in os %}
+ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
+{% endif %}
+
+{# Copy files needed by RAPIDS and 3rd parties for builds, test, and runtime. #}
+RUN mkdir -p ${RAPIDS_DIR}/utils {{ "${GCC7_DIR}/lib64" if "centos" in os }}
+COPY start_jupyter.sh nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
+
+{% if "centos" in os %}
+{# Add compatible libm #}
+COPY libm.so.6 ${GCC7_DIR}/lib64
+{% endif %}
+
 {# Install the notebook dependencies and the notebook repo #}
 {% include 'partials/env_debug.dockerfile.j2' %}
 


### PR DESCRIPTION
Similar to a previous fix, the new build process does not FROM `base` for `runtime` containers. So these steps that are taken in the `base` container need to be done in the `runtime` container. This should fix the error that was reported earlier.

#113 corrected the install where RAPIDS is in the container now, but without these additional lines the notebook server and other items do not work as expected.