### PR TITLE
FIX Add entrypoint to `runtime` images

### DIFF
--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -60,3 +60,6 @@ COPY .start_jupyter_run_in_rapids.sh /.run_in_rapids
 
 RUN conda clean -afy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
+ENTRYPOINT [ "/usr/bin/tini", "--", "/.run_in_rapids" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -60,3 +60,6 @@ COPY .start_jupyter_run_in_rapids.sh /.run_in_rapids
 
 RUN conda clean -afy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
+ENTRYPOINT [ "/usr/bin/tini", "--", "/.run_in_rapids" ]
+
+CMD [ "/bin/bash" ]

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -42,3 +42,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 {# Cleaup conda and set ACLs for all users #}
 {% include 'partials/cleanup-chmod.dockerfile.j2' %}
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/.run_in_rapids" ]
+
+{# Set the default command to pass to the ENTRYPOINT if no command was given #}
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This way the notebook server starts automatically and the images support passing commands like `python -c 'import cuml'`. Without the entrypoint definition the `rapids` conda environment is not activated and we only see the base environment. The `.run_in_rapids` file is overridden with a runtime version in the notebooks install partial template.