### PR TITLE
FIX Correct Dockerfile selection in gpuCI script

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -18,11 +18,14 @@ gpuci_logger "Logging into Docker..."
 echo $DH_TOKEN | docker login --username $DH_USER --password-stdin
 
 # Select dockerfile based on matrix var
-if (echo ${LINUX_VERSION} | grep -i ubuntu); then
-  DOCKERFILE=ubuntu18.04-${IMAGE_TYPE}.Dockerfile
+if [ "${LINUX_VER}" == "ubuntu16.04" ]; then
+  # ubuntu16.04 uses ubuntu18.04's Dockerfile
+  DOCKERFILE="ubuntu18.04-${IMAGE_TYPE}.Dockerfile"
 else
-  DOCKERFILE=centos7-${IMAGE_TYPE}.Dockerfile
+  # ubuntu18.04 & centos7 use their variables to select the Dockerfile
+  DOCKERFILE="${LINUX_VER}-${IMAGE_TYPE}.Dockerfile"
 fi
+gpuci_logger "Using Dockerfile: generated-dockerfiles/${DOCKERFILE}"
 
 # Debug output selected dockerfile
 gpuci_logger ">>>> BEGIN Dockerfile <<<<"


### PR DESCRIPTION
The previous selector chose the `centos7` Dockerfiles for `ubuntu16.04` and `ubuntu18.04`. This resulted in errors with the build that prevented the ENTRYPOINT to work correctly and despite local builds working, the produced builds from gpuCI did not have the correct `/rapids` directory and the necessary scripts/notebooks as expected.

I tested these changes in the gpuCI script job and confirmed they work as expected.