### PR TITLE
[REVIEW] Temporary Devel Ccache Fix

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,8 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-
 RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -150,37 +150,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -193,10 +201,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,12 +15,13 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN yum install -y \
+    openssl-devel libcurl-openssl-devel zlib-devel libcurl-devel \
+    && yum clean all
+
+
+
+
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,6 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN cd ${RAPIDS_DIR} \
+  && source activate rapids
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
@@ -24,7 +26,7 @@ RUN apt-get update -y --fix-missing \
       screen \
       tzdata \
       vim \
-      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+      libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
@@ -40,7 +42,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DZSTD_FROM_INTERNET=ON .. \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -29,14 +29,7 @@ RUN apt-get update -y --fix-missing \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,12 +35,12 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+    -DZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,21 +15,15 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN cd ${RAPIDS_DIR} \
-  && source activate rapids
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      jq \
-      libnuma1 \
-      libnuma-dev \
-      screen \
-      tzdata \
-      vim \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,10 +15,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.11
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
+  && ./autogen.sh \
+  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
+  && make install -j \
+  && cd / \
+  && rm -rf /tmp/ccache* \
+  && mkdir -p /ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,14 +15,10 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
-  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
-  && ./autogen.sh \
-  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-  && make install -j \
-  && cd / \
-  && rm -rf /tmp/ccache* \
-  && mkdir -p /ccache
+ARG CCACHE_VERSION=3.7.9
+RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
+ && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
+ && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,10 +15,21 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.9
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
+ && cmake \
+    -DENABLE_TESTING=OFF \
+    -DUSE_LIBB2_FROM_INTERNET=ON \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+ && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -20,8 +20,6 @@ RUN yum install -y \
     && yum clean all
 
 
-
-
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,6 +15,18 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      jq \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -16,6 +16,11 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 
+RUN apt-get update -y --fix-missing \
+    && apt-get install -y \
+      libssl-dev libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-quick.Dockerfile
+++ b/generated-dockerfiles/centos7-quick.Dockerfile
@@ -46,37 +46,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -89,10 +97,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,8 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-
 RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,12 +15,16 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+
 RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get -qq install apt-utils -y --no-install-recommends \
+  && apt-get install -y \
+    libssl-dev libcurl4-openssl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+
+
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -148,37 +148,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -191,10 +199,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -23,8 +23,6 @@ RUN apt-get update -y --fix-missing \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-
-
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,6 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN cd ${RAPIDS_DIR} \
+  && source activate rapids
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
@@ -24,7 +26,7 @@ RUN apt-get update -y --fix-missing \
       screen \
       tzdata \
       vim \
-      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+      libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
@@ -40,7 +42,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DZSTD_FROM_INTERNET=ON .. \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -29,14 +29,7 @@ RUN apt-get update -y --fix-missing \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,12 +35,12 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+    -DZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,21 +15,15 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN cd ${RAPIDS_DIR} \
-  && source activate rapids
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      jq \
-      libnuma1 \
-      libnuma-dev \
-      screen \
-      tzdata \
-      vim \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,10 +15,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.11
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
+  && ./autogen.sh \
+  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
+  && make install -j \
+  && cd / \
+  && rm -rf /tmp/ccache* \
+  && mkdir -p /ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,14 +15,10 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
-  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
-  && ./autogen.sh \
-  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-  && make install -j \
-  && cd / \
-  && rm -rf /tmp/ccache* \
-  && mkdir -p /ccache
+ARG CCACHE_VERSION=3.7.9
+RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
+ && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
+ && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,10 +15,21 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.9
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
+ && cmake \
+    -DENABLE_TESTING=OFF \
+    -DUSE_LIBB2_FROM_INTERNET=ON \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+ && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,6 +15,18 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      jq \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -16,6 +16,11 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 
+RUN apt-get update -y --fix-missing \
+    && apt-get install -y \
+      libssl-dev libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-quick.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-quick.Dockerfile
@@ -46,37 +46,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -89,10 +97,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,10 +16,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-ARG CCACHE_VERSION=3.7.11
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
+  && ./autogen.sh \
+  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
+  && make install -j \
+  && cd / \
+  && rm -rf /tmp/ccache* \
+  && mkdir -p /ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -30,14 +30,7 @@ RUN apt-get update -y --fix-missing \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,10 +16,21 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-ARG CCACHE_VERSION=3.7.9
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
+ && cmake \
+    -DENABLE_TESTING=OFF \
+    -DUSE_LIBB2_FROM_INTERNET=ON \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+ && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -17,6 +17,11 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_V
 
 {# Install ccache from source (use specific version in projects commit history) #}
 
+RUN apt-get update -y --fix-missing \
+    && apt-get install -y \
+      libssl-dev libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,14 +16,10 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
-  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
-  && ./autogen.sh \
-  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-  && make install -j \
-  && cd / \
-  && rm -rf /tmp/ccache* \
-  && mkdir -p /ccache
+ARG CCACHE_VERSION=3.7.9
+RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
+ && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
+ && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -32,9 +32,7 @@ RUN apt-get update -y --fix-missing \
   && rm -rf /var/lib/apt/lists/*
 {% endif %}
 
-
 {# Install ccache from source (use specific version in projects commit history) #}
-
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,21 +16,15 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-RUN cd ${RAPIDS_DIR} \
-  && source activate rapids
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      jq \
-      libnuma1 \
-      libnuma-dev \
-      screen \
-      tzdata \
-      vim \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,6 +16,18 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      jq \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -15,13 +15,26 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-{# Install ccache from source (use specific version in projects commit history) #}
+{% if "centos" in os %}
+{# TEMPORARY packages needed for ccache build #}
+RUN yum install -y \
+    openssl-devel libcurl-openssl-devel zlib-devel libcurl-devel \
+    && yum clean all
+{% endif %}
+
+{% if "ubuntu" in os %}
+{# TEMPORARY packages needed for ccache build #}
 RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get -qq install apt-utils -y --no-install-recommends \
+  && apt-get install -y \
+    libssl-dev libcurl4-openssl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+{% endif %}
+
+
+{# Install ccache from source (use specific version in projects commit history) #}
+
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,6 +16,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
+RUN cd ${RAPIDS_DIR} \
+  && source activate rapids
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
@@ -25,7 +27,7 @@ RUN apt-get update -y --fix-missing \
       screen \
       tzdata \
       vim \
-      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+      libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
@@ -41,7 +43,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DZSTD_FROM_INTERNET=ON .. \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,12 +36,12 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+    -DZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,8 +16,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-
 RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \

--- a/templates/partials/devel_build.dockerfile.j2
+++ b/templates/partials/devel_build.dockerfile.j2
@@ -10,6 +10,7 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 {% for lib in RAPIDS_LIBS %}
 RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   source activate rapids && \
+  ccache -s && \
   {% if lib.name == "cudf" %}
   ./build.sh && \
   ./build.sh tests


### PR DESCRIPTION
With the update to ccache 3.7.11 the cache has been bloating up to 4.2 GB and not performing well. I have found a range of commit's in ccache's master branch that both solve the cmake `Cannot build a simple test program`  error experienced last week and keep ccache performing as it previously did. The PR installs ccache at a commit in this Goldilocks Zone.

This is a temporary fix and early next week this code will be replaced with the work in progress conda based install (https://github.com/rapidsai/ccache-feedstock/tree/enh-rapids-ccache)