### PR TITLE
[REVIEW] Install ccache with forked ccache-feedstock package

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -20,6 +20,7 @@ RUN source activate rapids \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
 RUN conda install conda-build
+RUN echo "$(pwd)"
 RUN conda build .
 RUN conda install --use-local ccache
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,8 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-
 RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -19,6 +19,7 @@ RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
+RUN conda config --add channels conda-forge
 RUN conda install conda-build
 RUN conda update conda
 RUN echo "$(pwd)"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -22,7 +22,7 @@ RUN source activate rapids \
 RUN conda install conda-build
 RUN echo "$(pwd)"
 RUN conda build .
-RUN conda install --use-local ccache
+RUN conda install -c conda-forge --use-local ccache
 
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -22,8 +22,8 @@ RUN source activate rapids \
 RUN conda install conda-build
 RUN conda update conda
 RUN echo "$(pwd)"
-RUN conda build -c conda-forge .
-RUN conda install -c conda-forge --use-local ccache
+RUN conda build . -c conda-forge
+RUN conda install --use-local ccache -c conda-forge
 
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -24,13 +24,13 @@ ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 RUN which gcc
 RUN which ccache
-ENV CC="/usr/bin/gcc"
-ENV CXX="/usr/bin/g++"
-ENV NVCC="/usr/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
+ENV CUDAHOSTCXX="/usr/local/bin/g++"
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
 
 COPY ccache /ccache
 RUN ccache -s

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -22,8 +22,6 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
-RUN which gcc
-RUN which ccache
 ENV CC="/usr/local/bin/gcc"
 ENV CXX="/usr/local/bin/g++"
 ENV NVCC="/usr/local/bin/nvcc"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -150,37 +150,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -193,10 +201,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,12 +15,13 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN yum install -y \
+    openssl-devel libcurl-openssl-devel zlib-devel libcurl-devel \
+    && yum clean all
+
+
+
+
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,6 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN cd ${RAPIDS_DIR} \
+  && source activate rapids
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
@@ -24,7 +26,7 @@ RUN apt-get update -y --fix-missing \
       screen \
       tzdata \
       vim \
-      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+      libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
@@ -40,7 +42,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DZSTD_FROM_INTERNET=ON .. \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,9 +15,7 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN source activate rapids \
- && conda install -c gpuci gpuci-ccache
-
+RUN conda install -c gpuci gpuci-ccache
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -29,14 +29,7 @@ RUN apt-get update -y --fix-missing \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -18,9 +18,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_V
 RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
- && cd recipe \
- && conda build . \
- && conda install --use-local ccache
+ && cd recipe 
+RUN conda build .
+RUN conda install --use-local ccache
 
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -19,6 +19,7 @@ RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
+RUN conda install conda-build
 RUN conda build .
 RUN conda install --use-local ccache
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,8 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN source activate rapids
-RUN conda install -c gpuci gpuci-ccache
+RUN source activate rapids \
+ && conda install -c gpuci gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -20,6 +20,7 @@ RUN source activate rapids \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
 RUN conda install conda-build
+RUN conda update conda
 RUN echo "$(pwd)"
 RUN conda build -c conda-forge .
 RUN conda install -c conda-forge --use-local ccache

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,12 +35,12 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+    -DZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,17 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN source activate rapids \
- && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
- && git checkout enh-rapids-ccache  \
- && cd recipe 
-RUN conda config --add channels conda-forge
-RUN conda install conda-build
-RUN conda update conda
-RUN echo "$(pwd)"
-RUN conda build . -c conda-forge
-RUN conda install --use-local ccache -c conda-forge
-
+RUN source activate rapids
+RUN conda install gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,21 +15,15 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN cd ${RAPIDS_DIR} \
-  && source activate rapids
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      jq \
-      libnuma1 \
-      libnuma-dev \
-      screen \
-      tzdata \
-      vim \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -21,7 +21,7 @@ RUN source activate rapids \
  && cd recipe 
 RUN conda install conda-build
 RUN echo "$(pwd)"
-RUN conda build .
+RUN conda build -c conda-forge .
 RUN conda install -c conda-forge --use-local ccache
 
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,10 +15,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.11
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
+  && ./autogen.sh \
+  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
+  && make install -j \
+  && cd / \
+  && rm -rf /tmp/ccache* \
+  && mkdir -p /ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -27,13 +27,13 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
-ENV CC="/usr/local/bin/gcc"
-ENV CXX="/usr/local/bin/g++"
-ENV NVCC="/usr/local/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/local/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/bin/nvcc"
+ENV CUDAHOSTCXX="/usr/bin/g++"
+RUN ln -s "$(which ccache)" "/usr/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/bin/nvcc"
 
 COPY ccache /ccache
 RUN ccache -s

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,14 +15,10 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
-  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
-  && ./autogen.sh \
-  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-  && make install -j \
-  && cd / \
-  && rm -rf /tmp/ccache* \
-  && mkdir -p /ccache
+ARG CCACHE_VERSION=3.7.9
+RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
+ && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
+ && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -16,7 +16,7 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 RUN source activate rapids
-RUN conda install gpuci-ccache
+RUN conda install -c gpuci gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -27,6 +27,7 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
+RUN which gcc
 ENV CC="/usr/bin/gcc"
 ENV CXX="/usr/bin/g++"
 ENV NVCC="/usr/bin/nvcc"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,10 +15,21 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.9
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
+ && cmake \
+    -DENABLE_TESTING=OFF \
+    -DUSE_LIBB2_FROM_INTERNET=ON \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+ && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -20,8 +20,6 @@ RUN yum install -y \
     && yum clean all
 
 
-
-
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,6 +15,18 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      jq \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -16,6 +16,11 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 
+RUN apt-get update -y --fix-missing \
+    && apt-get install -y \
+      libssl-dev libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -28,6 +28,7 @@ ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 RUN which gcc
+RUN which ccache
 ENV CC="/usr/bin/gcc"
 ENV CXX="/usr/bin/g++"
 ENV NVCC="/usr/bin/nvcc"

--- a/generated-dockerfiles/centos7-quick.Dockerfile
+++ b/generated-dockerfiles/centos7-quick.Dockerfile
@@ -46,37 +46,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -89,10 +97,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -20,6 +20,7 @@ RUN source activate rapids \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
 RUN conda install conda-build
+RUN echo "$(pwd)"
 RUN conda build .
 RUN conda install --use-local ccache
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,8 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-
 RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,12 +15,16 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+
 RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get -qq install apt-utils -y --no-install-recommends \
+  && apt-get install -y \
+    libssl-dev libcurl4-openssl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+
+
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -19,6 +19,7 @@ RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
+RUN conda config --add channels conda-forge
 RUN conda install conda-build
 RUN conda update conda
 RUN echo "$(pwd)"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -148,37 +148,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -191,10 +199,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -22,7 +22,7 @@ RUN source activate rapids \
 RUN conda install conda-build
 RUN echo "$(pwd)"
 RUN conda build .
-RUN conda install --use-local ccache
+RUN conda install -c conda-forge --use-local ccache
 
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -22,8 +22,8 @@ RUN source activate rapids \
 RUN conda install conda-build
 RUN conda update conda
 RUN echo "$(pwd)"
-RUN conda build -c conda-forge .
-RUN conda install -c conda-forge --use-local ccache
+RUN conda build . -c conda-forge
+RUN conda install --use-local ccache -c conda-forge
 
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -24,13 +24,13 @@ ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 RUN which gcc
 RUN which ccache
-ENV CC="/usr/bin/gcc"
-ENV CXX="/usr/bin/g++"
-ENV NVCC="/usr/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
+ENV CUDAHOSTCXX="/usr/local/bin/g++"
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
 
 COPY ccache /ccache
 RUN ccache -s

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -23,8 +23,6 @@ RUN apt-get update -y --fix-missing \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-
-
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -22,8 +22,6 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
-RUN which gcc
-RUN which ccache
 ENV CC="/usr/local/bin/gcc"
 ENV CXX="/usr/local/bin/g++"
 ENV NVCC="/usr/local/bin/nvcc"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,6 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN cd ${RAPIDS_DIR} \
+  && source activate rapids
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
@@ -24,7 +26,7 @@ RUN apt-get update -y --fix-missing \
       screen \
       tzdata \
       vim \
-      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+      libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
@@ -40,7 +42,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DZSTD_FROM_INTERNET=ON .. \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,9 +15,7 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN source activate rapids \
- && conda install -c gpuci gpuci-ccache
-
+RUN conda install -c gpuci gpuci-ccache
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -29,14 +29,7 @@ RUN apt-get update -y --fix-missing \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -18,9 +18,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_V
 RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
- && cd recipe \
- && conda build . \
- && conda install --use-local ccache
+ && cd recipe 
+RUN conda build .
+RUN conda install --use-local ccache
 
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -19,6 +19,7 @@ RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
+RUN conda install conda-build
 RUN conda build .
 RUN conda install --use-local ccache
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,29 +15,13 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN source activate rapids \
+ && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
+ && git checkout enh-rapids-ccache  \
+ && cd recipe \
+ && conda build . \
+ && conda install --use-local ccache
 
-RUN apt-get update -y --fix-missing \
-  && apt-get -qq install apt-utils -y --no-install-recommends \
-  && apt-get install -y \
-    libssl-dev libcurl4-openssl-dev \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
- && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
- && cmake \
-    -DENABLE_TESTING=OFF \
-    -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
- && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,8 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN source activate rapids
-RUN conda install -c gpuci gpuci-ccache
+RUN source activate rapids \
+ && conda install -c gpuci gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -20,6 +20,7 @@ RUN source activate rapids \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
 RUN conda install conda-build
+RUN conda update conda
 RUN echo "$(pwd)"
 RUN conda build -c conda-forge .
 RUN conda install -c conda-forge --use-local ccache

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,12 +35,12 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+    -DZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,17 +15,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN source activate rapids \
- && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
- && git checkout enh-rapids-ccache  \
- && cd recipe 
-RUN conda config --add channels conda-forge
-RUN conda install conda-build
-RUN conda update conda
-RUN echo "$(pwd)"
-RUN conda build . -c conda-forge
-RUN conda install --use-local ccache -c conda-forge
-
+RUN source activate rapids
+RUN conda install gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,21 +15,15 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN cd ${RAPIDS_DIR} \
-  && source activate rapids
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      jq \
-      libnuma1 \
-      libnuma-dev \
-      screen \
-      tzdata \
-      vim \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -21,7 +21,7 @@ RUN source activate rapids \
  && cd recipe 
 RUN conda install conda-build
 RUN echo "$(pwd)"
-RUN conda build .
+RUN conda build -c conda-forge .
 RUN conda install -c conda-forge --use-local ccache
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,10 +15,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.11
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
+  && ./autogen.sh \
+  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
+  && make install -j \
+  && cd / \
+  && rm -rf /tmp/ccache* \
+  && mkdir -p /ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -27,13 +27,13 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
-ENV CC="/usr/local/bin/gcc"
-ENV CXX="/usr/local/bin/g++"
-ENV NVCC="/usr/local/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/local/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/bin/nvcc"
+ENV CUDAHOSTCXX="/usr/bin/g++"
+RUN ln -s "$(which ccache)" "/usr/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/bin/nvcc"
 
 COPY ccache /ccache
 RUN ccache -s

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,14 +15,10 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
-  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
-  && ./autogen.sh \
-  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-  && make install -j \
-  && cd / \
-  && rm -rf /tmp/ccache* \
-  && mkdir -p /ccache
+ARG CCACHE_VERSION=3.7.9
+RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
+ && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
+ && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -16,7 +16,7 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 RUN source activate rapids
-RUN conda install gpuci-ccache
+RUN conda install -c gpuci gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -27,6 +27,7 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
+RUN which gcc
 ENV CC="/usr/bin/gcc"
 ENV CXX="/usr/bin/g++"
 ENV NVCC="/usr/bin/nvcc"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,10 +15,21 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-ARG CCACHE_VERSION=3.7.9
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
+ && cmake \
+    -DENABLE_TESTING=OFF \
+    -DUSE_LIBB2_FROM_INTERNET=ON \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+ && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,6 +15,18 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      jq \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -16,6 +16,11 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 
+RUN apt-get update -y --fix-missing \
+    && apt-get install -y \
+      libssl-dev libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -28,6 +28,7 @@ ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 RUN which gcc
+RUN which ccache
 ENV CC="/usr/bin/gcc"
 ENV CXX="/usr/bin/g++"
 ENV NVCC="/usr/bin/nvcc"

--- a/generated-dockerfiles/ubuntu18.04-quick.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-quick.Dockerfile
@@ -46,37 +46,45 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh && \
   ./build.sh tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
+  ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
+  ccache -s && \
   ./build.sh
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
+  ccache -s && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
@@ -89,10 +97,12 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
 
 RUN cd ${RAPIDS_DIR}/dask-xgboost && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \
+  ccache -s && \
   python setup.py install
 
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -23,7 +23,7 @@ RUN source activate rapids \
 RUN conda install conda-build
 RUN echo "$(pwd)"
 RUN conda build .
-RUN conda install --use-local ccache
+RUN conda install -c conda-forge --use-local ccache
 
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,10 +16,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-ARG CCACHE_VERSION=3.7.11
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
+  && ./autogen.sh \
+  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
+  && make install -j \
+  && cd / \
+  && rm -rf /tmp/ccache* \
+  && mkdir -p /ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -22,7 +22,7 @@ RUN source activate rapids \
  && cd recipe 
 RUN conda install conda-build
 RUN echo "$(pwd)"
-RUN conda build .
+RUN conda build -c conda-forge .
 RUN conda install -c conda-forge --use-local ccache
 
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -30,14 +30,7 @@ RUN apt-get update -y --fix-missing \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -26,13 +26,13 @@ ENV CCACHE_COMPILERCHECK="%compiler% --version"
 {# Uncomment these env vars to force ccache to be enabled by default #}
 RUN which gcc
 RUN which ccache
-ENV CC="/usr/bin/gcc"
-ENV CXX="/usr/bin/g++"
-ENV NVCC="/usr/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
+ENV CUDAHOSTCXX="/usr/local/bin/g++"
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
 
 {# Add ccache folder and status check for ccache #}
 COPY ccache /ccache

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,10 +16,21 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-ARG CCACHE_VERSION=3.7.9
-RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
- && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
- && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
+ && cmake \
+    -DENABLE_TESTING=OFF \
+    -DUSE_LIBB2_FROM_INTERNET=ON \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+ && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -19,9 +19,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_V
 RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
- && cd recipe \
- && conda build . \
- && conda install --use-local ccache
+ && cd recipe 
+RUN conda build .
+RUN conda install --use-local ccache
 
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -21,6 +21,7 @@ RUN source activate rapids \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
 RUN conda install conda-build
+RUN echo "$(pwd)"
 RUN conda build .
 RUN conda install --use-local ccache
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -29,6 +29,7 @@ ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 {# Uncomment these env vars to force ccache to be enabled by default #}
+RUN which gcc
 ENV CC="/usr/bin/gcc"
 ENV CXX="/usr/bin/g++"
 ENV NVCC="/usr/bin/nvcc"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 5b32e9555acefec344fef1ad74c9a9cc0aebc750 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -21,6 +21,7 @@ RUN source activate rapids \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
 RUN conda install conda-build
+RUN conda update conda
 RUN echo "$(pwd)"
 RUN conda build -c conda-forge .
 RUN conda install -c conda-forge --use-local ccache

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -30,6 +30,7 @@ ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 {# Uncomment these env vars to force ccache to be enabled by default #}
 RUN which gcc
+RUN which ccache
 ENV CC="/usr/bin/gcc"
 ENV CXX="/usr/bin/g++"
 ENV NVCC="/usr/bin/nvcc"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -23,8 +23,8 @@ RUN source activate rapids \
 RUN conda install conda-build
 RUN conda update conda
 RUN echo "$(pwd)"
-RUN conda build -c conda-forge .
-RUN conda install -c conda-forge --use-local ccache
+RUN conda build . -c conda-forge
+RUN conda install --use-local ccache -c conda-forge
 
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -20,6 +20,7 @@ RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
+RUN conda install conda-build
 RUN conda build .
 RUN conda install --use-local ccache
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -17,6 +17,11 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_V
 
 {# Install ccache from source (use specific version in projects commit history) #}
 
+RUN apt-get update -y --fix-missing \
+    && apt-get install -y \
+      libssl-dev libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,14 +16,10 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
-  && git checkout -b rapids-compose-tmp b1fcfbca224b2af5b6499794edd8615dbc3dc7b5 \
-  && ./autogen.sh \
-  && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-  && make install -j \
-  && cd / \
-  && rm -rf /tmp/ccache* \
-  && mkdir -p /ccache
+ARG CCACHE_VERSION=3.7.9
+RUN curl -s -L https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o ccache-${CCACHE_VERSION}.tar.gz \
+ && tar -xvzf ccache-${CCACHE_VERSION}.tar.gz && cd ccache-${CCACHE_VERSION} \
+ && ./configure && make install -j16 && cd - && rm -rf ./ccache-${CCACHE_VERSION} ./ccache-${CCACHE_VERSION}.tar.gz
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -32,9 +32,7 @@ RUN apt-get update -y --fix-missing \
   && rm -rf /var/lib/apt/lists/*
 {% endif %}
 
-
 {# Install ccache from source (use specific version in projects commit history) #}
-
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,9 +16,7 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from conda package #}
-RUN source activate rapids \
- && conda install -c gpuci gpuci-ccache
-
+RUN conda install -c gpuci gpuci-ccache
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,21 +16,15 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-RUN cd ${RAPIDS_DIR} \
-  && source activate rapids
-RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      jq \
-      libnuma1 \
-      libnuma-dev \
-      screen \
-      tzdata \
-      vim \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
+
+ARG CMAKE_VERSION=3.17.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
+ && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
+ && ./bootstrap --system-curl --parallel=32 && make install -j32 \
+ && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
+ # Install ccache
+ && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
  && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
+ && git checkout -b rapids-compose-tmp 7f45074a264f1d4a2827369fb5019d35ff0b2c22 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,17 +16,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-RUN source activate rapids \
- && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
- && git checkout enh-rapids-ccache  \
- && cd recipe 
-RUN conda config --add channels conda-forge
-RUN conda install conda-build
-RUN conda update conda
-RUN echo "$(pwd)"
-RUN conda build . -c conda-forge
-RUN conda install --use-local ccache -c conda-forge
-
+RUN source activate rapids
+RUN conda install gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,6 +16,18 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      jq \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,8 +16,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from conda package #}
-RUN source activate rapids
-RUN conda install -c gpuci gpuci-ccache
+RUN source activate rapids \
+ && conda install -c gpuci gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -15,7 +15,7 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-{# Install ccache from source (use specific version in projects commit history) #}
+{# Install ccache from conda package #}
 RUN source activate rapids
 RUN conda install -c gpuci gpuci-ccache
 
@@ -24,8 +24,6 @@ ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 {# Uncomment these env vars to force ccache to be enabled by default #}
-RUN which gcc
-RUN which ccache
 ENV CC="/usr/local/bin/gcc"
 ENV CXX="/usr/local/bin/g++"
 ENV NVCC="/usr/local/bin/nvcc"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -15,13 +15,26 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-{# Install ccache from source (use specific version in projects commit history) #}
+{% if "centos" in os %}
+{# TEMPORARY packages needed for ccache build #}
+RUN yum install -y \
+    openssl-devel libcurl-openssl-devel zlib-devel libcurl-devel \
+    && yum clean all
+{% endif %}
+
+{% if "ubuntu" in os %}
+{# TEMPORARY packages needed for ccache build #}
 RUN apt-get update -y --fix-missing \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-    && apt-get install -y \
-      libssl-dev libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get -qq install apt-utils -y --no-install-recommends \
+  && apt-get install -y \
+    libssl-dev libcurl4-openssl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+{% endif %}
+
+
+{# Install ccache from source (use specific version in projects commit history) #}
+
 ARG CMAKE_VERSION=3.17.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,7 +36,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
+ && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -17,7 +17,7 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_V
 
 {# Install ccache from source (use specific version in projects commit history) #}
 RUN source activate rapids
-RUN conda install gpuci-ccache
+RUN conda install -c gpuci gpuci-ccache
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,6 +16,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
+RUN cd ${RAPIDS_DIR} \
+  && source activate rapids
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
@@ -25,7 +27,7 @@ RUN apt-get update -y --fix-missing \
       screen \
       tzdata \
       vim \
-      libssl-dev libcurl4-openssl-dev zlib1g-dev \
+      libssl-dev libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ARG CMAKE_VERSION=3.17.2
@@ -41,7 +43,7 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DZSTD_FROM_INTERNET=ON .. \
+    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -36,12 +36,12 @@ RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download
  && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
  # Install ccache
  && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp d64eb963a0c5557a2818cc0348966a10a6bcd07c \
+ && git checkout -b rapids-compose-tmp ea991027489f2e101f1355701bf32b3201e7c67a \
  && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
  && cmake \
     -DENABLE_TESTING=OFF \
     -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
+    -DZSTD_FROM_INTERNET=ON .. \
  && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
 
 ENV CCACHE_NOHASHDIR=

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -20,6 +20,7 @@ RUN source activate rapids \
  && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
  && git checkout enh-rapids-ccache  \
  && cd recipe 
+RUN conda config --add channels conda-forge
 RUN conda install conda-build
 RUN conda update conda
 RUN echo "$(pwd)"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -16,8 +16,8 @@ ARG FROM_IMAGE=gpuci/rapidsai
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
 {# Install ccache from source (use specific version in projects commit history) #}
-
 RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
       libssl-dev libcurl4-openssl-dev \
     && apt-get clean \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -15,39 +15,14 @@ ARG FROM_IMAGE=gpuci/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
-{% if "centos" in os %}
-{# TEMPORARY packages needed for ccache build #}
-RUN yum install -y \
-    openssl-devel libcurl-openssl-devel zlib-devel libcurl-devel \
-    && yum clean all
-{% endif %}
-
-{% if "ubuntu" in os %}
-{# TEMPORARY packages needed for ccache build #}
-RUN apt-get update -y --fix-missing \
-  && apt-get -qq install apt-utils -y --no-install-recommends \
-  && apt-get install -y \
-    libssl-dev libcurl4-openssl-dev \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-{% endif %}
-
 {# Install ccache from source (use specific version in projects commit history) #}
-ARG CMAKE_VERSION=3.17.2
-ENV CMAKE_VERSION=${CMAKE_VERSION}
-RUN curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" \
- && tar -xvzf cmake-$CMAKE_VERSION.tar.gz && cd cmake-$CMAKE_VERSION \
- && ./bootstrap --system-curl --parallel=32 && make install -j32 \
- && cd - && rm -rf ./cmake-$CMAKE_VERSION ./cmake-$CMAKE_VERSION.tar.gz \
- # Install ccache
- && git clone https://github.com/ccache/ccache.git /tmp/ccache && cd /tmp/ccache \
- && git checkout -b rapids-compose-tmp e071bcfd37dfb02b4f1fa4b45fff8feb10d1cbd2 \
- && mkdir -p /tmp/ccache/build && cd /tmp/ccache/build \
- && cmake \
-    -DENABLE_TESTING=OFF \
-    -DUSE_LIBB2_FROM_INTERNET=ON \
-    -DUSE_LIBZSTD_FROM_INTERNET=ON .. \
- && make ccache -j32 && make install && cd / && rm -rf /tmp/ccache
+RUN source activate rapids \
+ && git clone https://github.com/rapidsai/ccache-feedstock.git /tmp/ccache-feedstock && cd /tmp/ccache-feedstock \
+ && git checkout enh-rapids-ccache  \
+ && cd recipe \
+ && conda build . \
+ && conda install --use-local ccache
+
 
 ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -29,13 +29,13 @@ ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
 {# Uncomment these env vars to force ccache to be enabled by default #}
-ENV CC="/usr/local/bin/gcc"
-ENV CXX="/usr/local/bin/g++"
-ENV NVCC="/usr/local/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/local/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/bin/nvcc"
+ENV CUDAHOSTCXX="/usr/bin/g++"
+RUN ln -s "$(which ccache)" "/usr/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/bin/nvcc"
 
 {# Add ccache folder and status check for ccache #}
 COPY ccache /ccache

--- a/templates/partials/devel_build.dockerfile.j2
+++ b/templates/partials/devel_build.dockerfile.j2
@@ -10,6 +10,7 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 {% for lib in RAPIDS_LIBS %}
 RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   source activate rapids && \
+  ccache -s && \
   {% if lib.name == "cudf" %}
   ./build.sh && \
   ./build.sh tests


### PR DESCRIPTION
Builds off of the recent changes in our forked version of the ccache feedstock https://github.com/rapidsai/ccache-feedstock/pull/1

The version of ccache in the `gpuci-ccache` package is a a specific commit in history which does not bloat ccache and does not not cause the cmake `cannot compile a simple test program` error.