### PR TITLE
Enable Jupyter to run in foreground with environment variable

### DIFF
--- a/context/.start_jupyter_run_in_rapids.sh
+++ b/context/.start_jupyter_run_in_rapids.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
-/rapids/utils/start_jupyter.sh > /dev/null
+
+# Run Jupyter in foreground if $JUPYTER_FG is set
+if [[ -v JUPYTER_FG ]]; then
+   OUTPUT="/dev/tty"
+else
+   OUTPUT="/dev/null"
+fi
+
+source /rapids/utils/start_jupyter.sh > "${OUTPUT}"
 echo "Notebook server successfully started, a JupyterLab instance has been executed!"
 echo "Make local folders visible by volume mounting to /rapids/notebook"
 echo "To access visit http://localhost:8888 on your host machine."
 echo 'Ensure the following arguments to "docker run" are added to expose the server ports to your host machine:
    -p 8888:8888 -p 8787:8787 -p 8786:8786'
-exec "$@" 
+exec "$@"

--- a/context/.start_jupyter_run_in_rapids.sh
+++ b/context/.start_jupyter_run_in_rapids.sh
@@ -2,11 +2,11 @@
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+OUTPUT="/dev/null"
+
 # Run Jupyter in foreground if $JUPYTER_FG is set
 if [[ -v JUPYTER_FG ]]; then
    OUTPUT="/dev/tty"
-else
-   OUTPUT="/dev/null"
 fi
 
 source /rapids/utils/start_jupyter.sh > "${OUTPUT}"

--- a/context/.start_jupyter_run_in_rapids.sh
+++ b/context/.start_jupyter_run_in_rapids.sh
@@ -5,7 +5,7 @@ conda activate rapids
 OUTPUT="/dev/null"
 
 # Run Jupyter in foreground if $JUPYTER_FG is set
-if [[ -v JUPYTER_FG ]]; then
+if [[ "${JUPYTER_FG}" == "true" ]]; then
    OUTPUT="/dev/tty"
 fi
 

--- a/context/start_jupyter.sh
+++ b/context/start_jupyter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run Jupyter in foreground if $JUPYTER_FG is set
-if [[ -v JUPYTER_FG ]]; then
+if [[ "${JUPYTER_FG}" == "true" ]]; then
    jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
    exit 0
 fi

--- a/context/start_jupyter.sh
+++ b/context/start_jupyter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
+nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > .jupyter_lab_output.txt 2>&1 &
 echo -e "\n"
-echo "nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &"
+echo "nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > .jupyter_lab_output.txt 2>&1 &"
 echo -e "\n"

--- a/context/start_jupyter.sh
+++ b/context/start_jupyter.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > .jupyter_lab_output.txt 2>&1 &
+
+# Run Jupyter in foreground if $JUPYTER_FG is set
+if [[ -v JUPYTER_FG ]]; then
+   jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
+   exit 0
+fi
+
+nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
 echo -e "\n"
-echo "nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > .jupyter_lab_output.txt 2>&1 &"
+echo "nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &"
 echo -e "\n"


### PR DESCRIPTION
This PR addresses #133. It enables the `jupyter-lab` server to run in the foreground if the environment variable `JUPYTER_FG` is passed to `docker run`.

i.e: `docker run --gpus all -it -e JUPYTER_FG=true --rm jtest:latest`

![image](https://user-images.githubusercontent.com/7400326/89687346-15461b00-d8ce-11ea-8697-9df61477b9bf.png)


and without the var: `docker run --gpus all -it --rm jtest:latest`

![image](https://user-images.githubusercontent.com/7400326/89687402-30188f80-d8ce-11ea-98b0-1252236ac45a.png)



Closes #133.