### PR TITLE
FIX Add 0.16 RAPIDS to nightly axis

### DIFF
--- a/ci/axis/base-runtime.yaml
+++ b/ci/axis/base-runtime.yaml
@@ -11,6 +11,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.15
+  - 0.16
   
 RAPIDS_CHANNEL:
   - rapidsai-nightly
@@ -32,6 +33,8 @@ exclude:
   - RAPIDS_VER: 0.14
     RAPIDS_CHANNEL: rapidsai-nightly
   - RAPIDS_VER: 0.15
+    RAPIDS_CHANNEL: rapidsai
+  - RAPIDS_VER: 0.16
     RAPIDS_CHANNEL: rapidsai
   - BUILD_IMAGE: rapidsai/rapidsai
     RAPIDS_CHANNEL: rapidsai-nightly

--- a/ci/axis/devel.yaml
+++ b/ci/axis/devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.15
+  - 0.16
   
 RAPIDS_CHANNEL:
   - rapidsai-nightly
@@ -31,6 +32,8 @@ exclude:
   - RAPIDS_VER: 0.14
     RAPIDS_CHANNEL: rapidsai-nightly
   - RAPIDS_VER: 0.15
+    RAPIDS_CHANNEL: rapidsai
+  - RAPIDS_VER: 0.16
     RAPIDS_CHANNEL: rapidsai
   - BUILD_IMAGE: rapidsai/rapidsai-dev
     RAPIDS_CHANNEL: rapidsai-nightly


### PR DESCRIPTION
This creates nightly RAPIDS images as burndown started yesterday.

Blocked by: rapidsai/gpuci-build-environment#116