### PR TITLE
[REVIEW] Add libcumlprims to conda install

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -51,6 +51,7 @@ RUN source activate rapids \
 RUN gpuci_retry conda install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
+      libcumlprims=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER}

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -54,6 +54,7 @@ RUN source activate rapids \
 RUN gpuci_retry conda install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
+      libcumlprims=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER}

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -63,6 +63,7 @@ between packages. #}
 RUN gpuci_retry conda install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
+      libcumlprims=${RAPIDS_VER} \
     && conda remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER}


### PR DESCRIPTION
Devel builds are failing to find libcumlprims this should fix devel builds while keeping 0.16 images unblocked https://github.com/rapidsai/integration/pull/95