### PR TITLE
Removed some if statement duplication and pipe to tty

### DIFF
--- a/context/.start_jupyter_run_in_rapids.sh
+++ b/context/.start_jupyter_run_in_rapids.sh
@@ -2,17 +2,6 @@
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-OUTPUT="/dev/null"
+source /rapids/utils/start_jupyter.sh
 
-# Run Jupyter in foreground if $JUPYTER_FG is set
-if [[ "${JUPYTER_FG}" == "true" ]]; then
-   OUTPUT="/dev/tty"
-fi
-
-source /rapids/utils/start_jupyter.sh > "${OUTPUT}"
-echo "Notebook server successfully started, a JupyterLab instance has been executed!"
-echo "Make local folders visible by volume mounting to /rapids/notebook"
-echo "To access visit http://localhost:8888 on your host machine."
-echo 'Ensure the following arguments to "docker run" are added to expose the server ports to your host machine:
-   -p 8888:8888 -p 8787:8787 -p 8786:8786'
 exec "$@"

--- a/context/start_jupyter.sh
+++ b/context/start_jupyter.sh
@@ -5,9 +5,7 @@ if [[ "${JUPYTER_FG}" == "true" ]]; then
    jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
    exit 0
 else
-   set -x
    nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
-   set +x
 
    echo "Notebook server successfully started, a JupyterLab instance has been executed!"
    echo "Make local folders visible by volume mounting to /rapids/notebook"
@@ -15,4 +13,3 @@ else
    echo 'Ensure the following arguments to "docker run" are added to expose the server ports to your host machine:
       -p 8888:8888 -p 8787:8787 -p 8786:8786'
 fi
-

--- a/context/start_jupyter.sh
+++ b/context/start_jupyter.sh
@@ -4,9 +4,15 @@
 if [[ "${JUPYTER_FG}" == "true" ]]; then
    jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
    exit 0
+else
+   set -x
+   nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
+   set +x
+
+   echo "Notebook server successfully started, a JupyterLab instance has been executed!"
+   echo "Make local folders visible by volume mounting to /rapids/notebook"
+   echo "To access visit http://localhost:8888 on your host machine."
+   echo 'Ensure the following arguments to "docker run" are added to expose the server ports to your host machine:
+      -p 8888:8888 -p 8787:8787 -p 8786:8786'
 fi
 
-nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
-echo -e "\n"
-echo "nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &"
-echo -e "\n"


### PR DESCRIPTION
Made a few changes which should fix the problem I've found in #133 and also condensed the logic a little.

- Instead of piping to `/dev/tty` I've changed this to not pipe at all.
- Simplified `.start_jupyter_run_in_rapids.sh ` and moved all the foreground/background logic to `start_jupyter.sh`.
- Moved background logic into else statement. I feel this makes things more readable as it's easy to miss the short circuit `exit 0` line.
- Remove the command printing and used `set -x` instead. I've just done this for the one line being printed but it may be helpful to just do this for the whole entrypoint script.

