### PR TITLE
[REVIEW] Install nvdashboard using conda instead of pip

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -70,7 +70,7 @@ RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER}
 
 RUN source activate rapids \
-  && pip install "git+https://github.com/rapidsai/jupyterlab-nvdashboard.git@master#egg=jupyterlab-nvdashboard" --upgrade \
+  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER}
 
 RUN source activate rapids \
-  && pip install "git+https://github.com/rapidsai/jupyterlab-nvdashboard.git@master#egg=jupyterlab-nvdashboard" --upgrade \
+  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -73,7 +73,7 @@ RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER}
 
 RUN source activate rapids \
-  && pip install "git+https://github.com/rapidsai/jupyterlab-nvdashboard.git@master#egg=jupyterlab-nvdashboard" --upgrade \
+  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER}
 
 RUN source activate rapids \
-  && pip install "git+https://github.com/rapidsai/jupyterlab-nvdashboard.git@master#egg=jupyterlab-nvdashboard" --upgrade \
+  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/templates/partials/install_notebooks.dockerfile.j2
+++ b/templates/partials/install_notebooks.dockerfile.j2
@@ -8,7 +8,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 {# Install jupyter lab stuff #}
 RUN source activate rapids \
-  && pip install "git+https://github.com/rapidsai/jupyterlab-nvdashboard.git@master#egg=jupyterlab-nvdashboard" --upgrade \
+  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 {# Install notebooks repo #}


### PR DESCRIPTION
This makes sure we always pick up the latest release of nvdashboard. Currently there are conflicts with cuxfilter's bokeh version.