### PR TITLE
FIX Paths and Symlinks for Centos7

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -20,13 +20,14 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
-ENV CC="/usr/local/bin/gcc"
-ENV CXX="/usr/local/bin/g++"
+
+ENV CC="/usr/local/gcc7/bin/gcc"
+ENV CXX="/usr/local/gcc7/bin/g++"
 ENV NVCC="/usr/local/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/local/bin/g++"
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+RUN ln -s "$(which ccache)" "/usr/local/gcc7/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/gcc7/bin/g++" \
     && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 
 COPY ccache /ccache
 RUN ccache -s

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -23,10 +23,11 @@ ENV CCACHE_COMPILERCHECK="%compiler% --version"
 ENV CC="/usr/local/bin/gcc"
 ENV CXX="/usr/local/bin/g++"
 ENV NVCC="/usr/local/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/local/bin/g++"
 RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
     && ln -s "$(which ccache)" "/usr/local/bin/g++" \
     && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
+
 
 COPY ccache /ccache
 RUN ccache -s

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -21,14 +21,25 @@ ENV CCACHE_NOHASHDIR=
 ENV CCACHE_DIR="/ccache"
 ENV CCACHE_COMPILERCHECK="%compiler% --version"
 
-{# Uncomment these env vars to force ccache to be enabled by default #}
+{# Set ccache symlinks and environment variables #}
+{% if "ubuntu" in os %}
 ENV CC="/usr/local/bin/gcc"
 ENV CXX="/usr/local/bin/g++"
 ENV NVCC="/usr/local/bin/nvcc"
-ENV CUDAHOSTCXX="/usr/local/bin/g++"
 RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
     && ln -s "$(which ccache)" "/usr/local/bin/g++" \
     && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+{% endif %}
+
+{% if "centos" in os %}
+ENV CC="/usr/local/gcc7/bin/gcc"
+ENV CXX="/usr/local/gcc7/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
+RUN ln -s "$(which ccache)" "/usr/local/gcc7/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/gcc7/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+{% endif %}
+
 
 {# Add ccache folder and status check for ccache #}
 COPY ccache /ccache


### PR DESCRIPTION
Docker cuDF tests are currently failing on centos. This is because the tests use the system gcc versions which are out of date and instead of the manually installed gcc7.

This PR fixes ccache to symlink to the correct gcc version on centos.