### PR TITLE
[REVIEW] [FIX] Fix docker run commands for notebooks

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -69,8 +69,9 @@ RUN gpuci_conda_retry install -y -n rapids \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}
 
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+
 RUN source activate rapids \
-  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -39,8 +39,9 @@ RUN gpuci_conda_retry install -y -n rapids \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}
 
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+
 RUN source activate rapids \
-  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -72,8 +72,9 @@ RUN gpuci_conda_retry install -y -n rapids \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}
 
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+
 RUN source activate rapids \
-  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -39,8 +39,9 @@ RUN gpuci_conda_retry install -y -n rapids \
     && conda remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER}
 
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+
 RUN source activate rapids \
-  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \

--- a/templates/partials/install_notebooks.dockerfile.j2
+++ b/templates/partials/install_notebooks.dockerfile.j2
@@ -7,8 +7,9 @@ RUN gpuci_conda_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER}
 
 {# Install jupyter lab stuff #}
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+
 RUN source activate rapids \
-  && gpuci_conda_retry install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install dask-labextension jupyterlab-nvdashboard
 
 {# Install notebooks repo #}


### PR DESCRIPTION
This PR separates the `source activate rapids` command from the `gpuci_conda_retry install` command. This is because `devel` images have `conda` installed in the `rapids` environment and therefore the wrong `conda` executable gets passed to `gpuci_conda_retry` when the `rapids` environment is activated in `devel` images.