### PR TITLE
FEA Add CUDA11 to docker images

### DIFF
--- a/ci/axis/base-runtime.yaml
+++ b/ci/axis/base-runtime.yaml
@@ -16,6 +16,7 @@ RAPIDS_CHANNEL:
   - rapidsai-nightly
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
 

--- a/ci/axis/devel.yaml
+++ b/ci/axis/devel.yaml
@@ -15,6 +15,7 @@ RAPIDS_CHANNEL:
   - rapidsai-nightly
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
 


### PR DESCRIPTION
Simple PR to add CUDA 11 to docker images (devel, base and runtime)