### PR TITLE
Update entrypoint script for NGC

### DIFF
--- a/context/.run_in_rapids.sh
+++ b/context/.run_in_rapids.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
-exec "$@"
+exec $@


### PR DESCRIPTION
`ngc batch run` accepts the user-supplied command (executable & arguments) as a single string, which is fed to the `/.run_in_rapids` script as one argument (e.g. `ngc batch run --commandline "echo hello world" ...` produces `/.run_in_rapids "echo hello world"`). If we `exec "$@"` then we end up trying to invoke an executable named "echo hello world", instead of an executable named "echo" with arguments "hello" and "world".

For a concrete example, invoking the rapids image like so:

```
ngc batch run --instance dgx1v.16g.1.norm --name "rapids-entrypoint" --image "nvidia/rapidsai/rapidsai:cuda10.2-base-ubuntu18.04" --result /result --commandline "echo hello world" --total-runtime 10M --use-image-entrypoint
```

produces the output:

```
/.run_in_rapids: line 4: exec: echo hello world: not found
```

The same happens even if we supply the same input through a json file:

```
{
    "aceInstance": "dgx1v.16g.1.norm",
    "aceName": "nv-us-west-2",
    "command": "echo hello world",
    "dockerImageName": "nvidia/rapidsai/rapidsai:cuda10.2-base-ubuntu18.04",
    "name": "rapids-entrypoint",
    "resultContainerMountPoint": "/result",
    "runPolicy": {
        "preemptClass": "RUNONCE",
        "totalRuntimeSeconds": 600
    },
    "useImageEntryPoint": true
}
```

With the proposed change the same NGC command line works as expected. It can't handle whitespace in arguments, but given the constraints of the NGC command-line interface, that would require a more involved solution.