### PR TITLE
Temporarily pin libcumlprims

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -58,7 +58,7 @@ RUN source activate rapids \
 RUN gpuci_retry conda install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
-      "libcumlprims=${RAPIDS_VER}*" \
+      "libcumlprims=0.16.0a200821" \
       "ucx-py=${RAPIDS_VER}*" \
     && conda remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -57,7 +57,7 @@ RUN source activate rapids \
 RUN gpuci_retry conda install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
-      "libcumlprims=${RAPIDS_VER}*" \
+      "libcumlprims=0.16.0a200821" \
       "ucx-py=${RAPIDS_VER}*" \
     && conda remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -71,7 +71,7 @@ between packages. #}
 RUN gpuci_retry conda install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
-      "libcumlprims=${RAPIDS_VER}*" \
+      "libcumlprims=0.16.0a200821" \
       "ucx-py=${RAPIDS_VER}*" \
     && conda remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \


### PR DESCRIPTION
This PR temporarily pins `libcumlprims` to same version as the link below to fix some breaking builds. It should be reverted once a more permanent fix is in place.

https://github.com/rapidsai/cuml/blob/branch-0.16/conda/recipes/libcuml/meta.yaml#L44