### PR TITLE
Revert "Temporarily pin libcumlprims"

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -58,7 +58,7 @@ RUN source activate rapids \
 RUN gpuci_retry conda install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
-      "libcumlprims=0.16.0a200821" \
+      "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${RAPIDS_VER}*" \
     && conda remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -57,7 +57,7 @@ RUN source activate rapids \
 RUN gpuci_retry conda install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
-      "libcumlprims=0.16.0a200821" \
+      "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${RAPIDS_VER}*" \
     && conda remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -71,7 +71,7 @@ between packages. #}
 RUN gpuci_retry conda install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
-      "libcumlprims=0.16.0a200821" \
+      "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${RAPIDS_VER}*" \
     && conda remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \


### PR DESCRIPTION
The `testing` label has been added to all `libcumlprims` packages that aren't stable ([src](https://anaconda.org/rapidsai-nightly/libcumlprims/files)), therefore #160 can be reverted.

Reverts rapidsai/docker#160