### PR TITLE
[REVIEW] Update PATH variable

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -9,7 +9,7 @@ export HOME=/home/rapids
 export USER=rapids
 export LOGNAME=rapids
 export MAIL=/var/spool/mail/rapids
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/rapids/bin
+export PATH=$PATH:/home/rapids/bin
 export supkg="su-exec"
 chown rapids:rapids $HOME
 


### PR DESCRIPTION
#143 overrode the `PATH` variable, which was a bad idea. This PR fixes that change to instead _append_ to the `PATH` variable so that previous `PATH` entries are retained.