### PR TITLE
[REVIEW] Update DockerHub docs

### DIFF
--- a/dockerhub-readme/Dockerhub_rapidsai-dev-nightly.md
+++ b/dockerhub-readme/Dockerhub_rapidsai-dev-nightly.md
@@ -40,7 +40,7 @@ For smaller RAPIDS Docker images consisting of a full conda-based install and no
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.13-cuda10.1-devel-ubuntu18.04-py3.7
+0.15-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -49,22 +49,44 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
  RAPIDS version        linux version
 ```
 
+To get the latest RAPIDS version of a specific platform combination, simply exclude the RAPIDS version.  For example, to pull the latest version of RAPIDS for the `runtime` image with support for CUDA 10.1, Python 3.7, and Ubuntu 18.04, use the following tag:
+```
+cuda10.1-devel-ubuntu18.04-py3.7
+```
+
+Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda10.1-devel-ubuntu16.04-py3.7`.
+
 ## Prerequisites
 
 * NVIDIA Pascal™ GPU architecture or better
-* CUDA [10.1](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 * Ubuntu 16.04/18.04 or CentOS 7
 * Docker CE v18+
 * [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
 
 ## Usage
 
-See [usage instructions](https://hub.docker.com/r/rapidsai/rapidsai#usage) for information and replace references to `rapidsai/rapidsai` with `rapidsai/rapidsai-dev-nightly`.
+See the _Usage_ section in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) for information and replace references to `rapidsai/rapidsai` with `rapidsai/rapidsai-dev-nightly`.
+
+### Runtime Arguments
+
+The arguments below only exist in the nightly images, however stable runtime arguments can also be used in the nightlies unless otherwise noted. To see a list of the stable runtime arguments, see the _Runtime Arguments_ section in [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev).
+
+The following environment variables can be passed to the `docker run` commands:
+
+- `HOST_USER_ID` - used to set the `uid` of the user when the container starts. Useful for ensuring that files written to Docker volumes do not belong to the `root` user
+
+Example:
+
+```sh
+$ docker run --runtime=nvidia --rm -it -e HOST_USER_ID=$(id -u $USER) -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+         rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.7
+```
 
 ## Where can I get help or file bugs/requests?
 
-For more information about the containers or to submit a container issue, visit: [https://github.com/rapidsai/build](https://github.com/rapidsai/build).
+Please submit issues with the container to this GitHub repository: [https://github.com/rapidsai/docs](https://github.com/rapidsai/docs/issues/new)
 
-For issues with RAPIDS libraries like cuDF, cuML, RMM, cuGraph, or others file an issue in the related GitHub project.
+For issues with RAPIDS libraries like cuDF, cuML, RMM, or others file an issue in the related GitHub project.
 
 Additional help can be found on [Stack Overflow](https://stackoverflow.com/tags/rapids) or [Google Groups](https://groups.google.com/forum/#!forum/rapidsai).

--- a/dockerhub-readme/Dockerhub_rapidsai-dev.md
+++ b/dockerhub-readme/Dockerhub_rapidsai-dev.md
@@ -14,21 +14,21 @@ Unlike the Docker images in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsa
 
 ### Current Version
 
-#### RAPIDS 0.13 - 31 March 2020
+#### RAPIDS 0.15 - 26 Aug 2020
 
-Versions of libraries included in the `0.13` images:
-- `cuDF` [v0.13.0](https://github.com/rapidsai/cudf/tree/v0.13.0), `cuML` [v0.13.0](https://github.com/rapidsai/cuml/tree/v0.13.0), `cuGraph` [v0.13.0](https://github.com/rapidsai/cugraph/tree/v0.13.0), `RMM` [v0.13.0](https://github.com/rapidsai/RMM/tree/v0.13.0), `cuSpatial` [v0.13.0](https://github.com/rapidsai/cuspatial/tree/v0.13.0), `cuxfilter` [v0.13.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.13)
-  - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.13-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.13)
+Versions of libraries included in the `0.15` images:
+- `cuDF` [v0.15](https://github.com/rapidsai/cudf/tree/v0.15.0), `cuML` [v0.15](https://github.com/rapidsai/cuml/tree/v0.15.0), `cuGraph` [v0.15](https://github.com/rapidsai/cugraph/tree/v0.15.0), `RMM` [v0.15](https://github.com/rapidsai/RMM/tree/v0.15.0), `cuSpatial` [v0.15](https://github.com/rapidsai/cuspatial/tree/v0.15.0), `cuSignal` [v0.15](https://github.com/rapidsai/cusignal/tree/v0.15.0), `cuxfilter` [v0.15](https://github.com/rapidsai/cuxfilter/tree/v0.15.0)
+  - **IMPORTANT:** CUDA 10.0 & Python 3.6 support ended in v0.14; v0.15 includes CUDA 11.0 & Python 3.8 support
+  - **NOTE:** See [RAPIDS Notices](https://docs.rapids.ai/notices) for release changes for `clx` as well as other recent changes
 
 ### Former Version
 
-#### RAPIDS 0.12 - 4 February 2020
+#### RAPIDS 0.14 - 3 June 2020
 
-Versions of libraries included in the `0.12` images:
-- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+Versions of libraries included in the `0.14` images:
+- `cuDF` [v0.14](https://github.com/rapidsai/cudf/tree/v0.14.0), `cuML` [v0.14](https://github.com/rapidsai/cuml/tree/v0.14.0), `cuGraph` [v0.14](https://github.com/rapidsai/cugraph/tree/v0.14.0), `RMM` [v0.14](https://github.com/rapidsai/RMM/tree/v0.14.0), `cuSpatial` [v0.14](https://github.com/rapidsai/cuspatial/tree/v0.14.0), `cuxfilter` [v0.14](https://github.com/rapidsai/cuxfilter/tree/v0.14.0), `cuSignal` [v0.14](https://github.com/rapidsai/cusignal/tree/v0.14.0)
   - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.14-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.14)
 
 ### Image Types
 
@@ -37,17 +37,21 @@ images in order to make it easy to add RAPIDS libraries while maintaining suppor
 
 RAPIDS images come in three types, distributed in two different repos:
 
-This repo (rapidsai-dev), contains the following:
+The [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai/tags) repo contains the following:
+- `base` - contains a RAPIDS environment ready for use.
+  - **TIP: Use this image if you want to use RAPIDS as a part of your pipeline.**
+- `runtime` - extends the `base` image by adding a notebook server and example notebooks.
+  - **TIP: Use this image if you want to explore RAPIDS through notebooks and examples.**
+
+The [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags) repo adds the following:
 - `devel` - contains the full RAPIDS source tree, pre-built with all artifacts in place, and the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development.
   - **TIP: Use this image to develop RAPIDS from source.**
-
-For smaller RAPIDS Docker images consisting of a full conda-based install and no development toolchain, refer to the `base` or `runtime` images in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) repo.
 
 ### Image Tag Naming Scheme
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.13-cuda10.1-devel-ubuntu18.04-py3.7
+0.15-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -56,10 +60,17 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
  RAPIDS version        linux version
 ```
 
+To get the latest RAPIDS version of a specific platform combination, simply exclude the RAPIDS version.  For example, to pull the latest version of RAPIDS for the `runtime` image with support for CUDA 10.1, Python 3.7, and Ubuntu 18.04, use the following tag:
+```
+cuda10.1-devel-ubuntu18.04-py3.7
+```
+
+Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda10.1-devel-ubuntu16.04-py3.7`.
+
 ## Prerequisites
 
 * NVIDIA Pascal™ GPU architecture or better
-* CUDA [10.1](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 * Ubuntu 16.04/18.04 or CentOS 7
 * Docker CE v18+
 * [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
@@ -70,17 +81,17 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-dev:cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-dev:cuda10.1-devel-ubuntu18.04-py3.7
 ```
 **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-dev:cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-dev:cuda10.1-devel-ubuntu18.04-py3.7
 ```
 **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
@@ -88,27 +99,20 @@ $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `HOST_USER_ID` - used to set the `uid` of the user when the container starts. Useful for ensuring that files written to Docker volumes do not belong to the `root` user
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background
-
-Example:
-
-```sh
-$ docker run --runtime=nvidia --rm -it -e HOST_USER_ID=$(id -u $USER) -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.7
-```
+- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.13 container:
+Notebooks can be found in the following directories within the 0.15 container:
 
-* `/rapids/notebooks/xgboost` - XGBoost demo notebooks
-* `/rapids/notebooks/cudf` - cuDF demo notebooks
-* `/rapids/notebooks/cuml` - cuML demo notebooks
+* `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
-* `/rapids/notebooks/tutorials` - Tutorials with end-to-end workflows
+* `/rapids/notebooks/cuml` - cuML demo notebooks
+* `/rapids/notebooks/cusignal` - cuSignal demo notebooks
+* `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.9/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.15/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -118,14 +122,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-dev:cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-dev:cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 
@@ -149,7 +153,7 @@ Learn how to setup a mult-node cuDF and XGBoost data preparation and distributed
 
 ## Where can I get help or file bugs/requests?
 
-For more information about the containers or to submit a container issue, visit: [https://github.com/rapidsai/build](https://github.com/rapidsai/build).
+Please submit issues with the container to this GitHub repository: [https://github.com/rapidsai/docs](https://github.com/rapidsai/docs/issues/new)
 
 For issues with RAPIDS libraries like cuDF, cuML, RMM, or others file an issue in the related GitHub project.
 

--- a/dockerhub-readme/Dockerhub_rapidsai-nightly.md
+++ b/dockerhub-readme/Dockerhub_rapidsai-nightly.md
@@ -14,12 +14,11 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-nightly` repo contains nightly docker builds of the latest WIP changes merged into Github repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) containers.
 
-#### RAPIDS NIGHTLY v0.14.0a
+#### RAPIDS NIGHTLY v0.16.0a
 
-Versions of libraries included in the `0.14` images:
-- `cuDF` [v0.14.0a](https://github.com/rapidsai/cudf), `cuML` [v0.14.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.14.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.14.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.14.0a](https://github.com/rapidsai/cuspatial), `cuxfilter` [v0.14.0a](https://github.com/rapidsai/cuxfilter)
-  - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
+Versions of libraries included in the `0.16` images:
+- `cuDF` [v0.16.0a](https://github.com/rapidsai/cudf), `cuML` [v0.16.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.16.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.16.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.16.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.16.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.16.0a](https://github.com/rapidsai/cuxfilter)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
 
@@ -42,7 +41,7 @@ The [rapidsai/rapidsai-dev-nightly](https://hub.docker.com/r/rapidsai/rapidsai-d
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.13-cuda10.1-runtime-ubuntu18.04-py3.7
+0.16-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -51,29 +50,44 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
  RAPIDS version        linux version
 ```
 
-To get the latest RAPIDS version of a specific platform combination, simply exclude the RAPIDS version.  For example, to pull the latest version of RAPIDS for the `runtime` image with support for CUDA 10.1, Python 3.7, and Ubuntu 18.04, use the following tag:
+To get the latest RAPIDS version of a specific platform combination, simply exclude the RAPIDS version.  For example, to pull the latest version of RAPIDS for the `runtime` image with support for CUDA 10.1, Python 3.6, and Ubuntu 18.04, use the following tag:
 ```
-cuda10.1-runtime-ubuntu18.04-py3.7
+cuda10.1-runtime-ubuntu18.04-py3.6
 ```
 
-Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda10.1-runtime-ubuntu16.04-py3.7`.
+Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda10.1-runtime-ubuntu16.04-py3.6`.
 
 ## Prerequisites
 
 * NVIDIA Pascal™ GPU architecture or better
-* CUDA [10.1](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 * Ubuntu 16.04/18.04 or CentOS 7
 * Docker CE v18+
 * [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
 
 ## Usage
 
-See [usage instructions](https://hub.docker.com/r/rapidsai/rapidsai#usage) for information and replace references to `rapidsai/rapidsai` with `rapidsai/rapidsai-nightly`.
+See the _Usage_ section in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) for information and replace references to `rapidsai/rapidsai` with `rapidsai/rapidsai-nightly`.
+
+### Runtime Arguments
+
+The arguments below only exist in the nightly images, however stable runtime arguments can also be used in the nightlies unless otherwise noted. To see a list of the stable runtime arguments, see the _Runtime Arguments_ section in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai).
+
+The following environment variables can be passed to the `docker run` commands:
+
+- `HOST_USER_ID` - used to set the `uid` of the user when the container starts. Useful for ensuring that files written to Docker volumes do not belong to the `root` user
+
+Example:
+
+```sh
+$ docker run --runtime=nvidia --rm -it -e HOST_USER_ID=$(id -u $USER) -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+         rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.7
+```
 
 ## Where can I get help or file bugs/requests?
 
-For more information about the containers or to submit a container issue, visit: [https://github.com/rapidsai/build](https://github.com/rapidsai/build).
+Please submit issues with the container to this GitHub repository: [https://github.com/rapidsai/docs](https://github.com/rapidsai/docs/issues/new)
 
-For issues with RAPIDS libraries like cuDF, cuML, RMM, cuGraph, or others file an issue in the related GitHub project.
+For issues with RAPIDS libraries like cuDF, cuML, RMM, or others file an issue in the related GitHub project.
 
 Additional help can be found on [Stack Overflow](https://stackoverflow.com/tags/rapids) or [Google Groups](https://groups.google.com/forum/#!forum/rapidsai).

--- a/dockerhub-readme/Dockerhub_rapidsai.md
+++ b/dockerhub-readme/Dockerhub_rapidsai.md
@@ -10,21 +10,21 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 ### Current Version
 
-#### RAPIDS 0.13 - 31 March 2020
+#### RAPIDS 0.15 - 26 Aug 2020
 
-Versions of libraries included in the `0.13` images:
-- `cuDF` [v0.13.0](https://github.com/rapidsai/cudf/tree/v0.13.0), `cuML` [v0.13.0](https://github.com/rapidsai/cuml/tree/v0.13.0), `cuGraph` [v0.13.0](https://github.com/rapidsai/cugraph/tree/v0.13.0), `RMM` [v0.13.0](https://github.com/rapidsai/RMM/tree/v0.13.0), `cuSpatial` [v0.13.0](https://github.com/rapidsai/cuspatial/tree/v0.13.0), `cuxfilter` [v0.13.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.13)
-  - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.13-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.13)
+Versions of libraries included in the `0.15` images:
+- `cuDF` [v0.15](https://github.com/rapidsai/cudf/tree/v0.15.0), `cuML` [v0.15](https://github.com/rapidsai/cuml/tree/v0.15.0), `cuGraph` [v0.15](https://github.com/rapidsai/cugraph/tree/v0.15.0), `RMM` [v0.15](https://github.com/rapidsai/RMM/tree/v0.15.0), `cuSpatial` [v0.15](https://github.com/rapidsai/cuspatial/tree/v0.15.0), `cuSignal` [v0.15](https://github.com/rapidsai/cusignal/tree/v0.15.0), `cuxfilter` [v0.15](https://github.com/rapidsai/cuxfilter/tree/v0.15.0)
+  - **IMPORTANT:** CUDA 10.0 & Python 3.6 support ended in v0.14; v0.15 includes CUDA 11.0 & Python 3.8 support
+  - **NOTE:** See [RAPIDS Notices](https://docs.rapids.ai/notices) for release changes for `clx` as well as other recent changes
 
 ### Former Version
 
-#### RAPIDS 0.12 - 4 February 2020
+#### RAPIDS 0.14 - 3 June 2020
 
-Versions of libraries included in the `0.12` images:
-- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+Versions of libraries included in the `0.14` images:
+- `cuDF` [v0.14](https://github.com/rapidsai/cudf/tree/v0.14.0), `cuML` [v0.14](https://github.com/rapidsai/cuml/tree/v0.14.0), `cuGraph` [v0.14](https://github.com/rapidsai/cugraph/tree/v0.14.0), `RMM` [v0.14](https://github.com/rapidsai/RMM/tree/v0.14.0), `cuSpatial` [v0.14](https://github.com/rapidsai/cuspatial/tree/v0.14.0), `cuxfilter` [v0.14](https://github.com/rapidsai/cuxfilter/tree/v0.14.0), `cuSignal` [v0.14](https://github.com/rapidsai/cusignal/tree/v0.14.0)
   - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.14-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.14)
 
 ### Image Types
 
@@ -33,7 +33,7 @@ images in order to make it easy to add RAPIDS libraries while maintaining suppor
 
 RAPIDS images come in three types, distributed in two different repos:
 
-This repo (rapidsai), contains the following:
+The [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai/tags) repo contains the following:
 - `base` - contains a RAPIDS environment ready for use.
   - **TIP: Use this image if you want to use RAPIDS as a part of your pipeline.**
 - `runtime` - extends the `base` image by adding a notebook server and example notebooks.
@@ -47,7 +47,7 @@ The [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags)
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.13-cuda10.1-runtime-ubuntu18.04-py3.7
+0.15-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -66,7 +66,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 * NVIDIA Pascal™ GPU architecture or better
-* CUDA [10.1](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 * Ubuntu 16.04/18.04 or CentOS 7
 * Docker CE v18+
 * [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
@@ -95,27 +95,27 @@ $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `HOST_USER_ID` - used to set the `uid` of the user when the container starts. Useful for ensuring that files written to Docker volumes do not belong to the `root` user
 - `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
 
 Example:
 
 ```sh
-$ docker run --runtime=nvidia --rm -it -e HOST_USER_ID=$(id -u $USER) -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+$ docker run --runtime=nvidia --rm -it -e JUPYTER_FG="true" -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.10 container:
+Notebooks can be found in the following directories within the 0.15 container:
 
-* `/rapids/notebooks/xgboost` - XGBoost demo notebooks
-* `/rapids/notebooks/cudf` - cuDF demo notebooks
-* `/rapids/notebooks/cuml` - cuML demo notebooks
+* `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
-* `/rapids/notebooks/tutorials` - Tutorials with end-to-end workflows
+* `/rapids/notebooks/cuml` - cuML demo notebooks
+* `/rapids/notebooks/cusignal` - cuSignal demo notebooks
+* `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.9/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.15/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -156,7 +156,7 @@ Learn how to setup a mult-node cuDF and XGBoost data preparation and distributed
 
 ## Where can I get help or file bugs/requests?
 
-For more information about the containers or to submit a container issue, visit: [https://github.com/rapidsai/build](https://github.com/rapidsai/build).
+Please submit issues with the container to this GitHub repository: [https://github.com/rapidsai/docs](https://github.com/rapidsai/docs/issues/new)
 
 For issues with RAPIDS libraries like cuDF, cuML, RMM, or others file an issue in the related GitHub project.
 


### PR DESCRIPTION
This PR updates the DockerHub docs. I mostly just copied the current DockerHub readmes back to this repo and updated some versions.

Once approved, I'll repaste these changes back to DockerHub.

There's a ton of duplication across these readmes which is annoying to reconcile manually, so we may want to consider Jinja-fying these docs.

Additionally, automating the updates to DockerHub as mentioned in [this card](https://github.com/orgs/rapidsai/projects/9#card-45194062) would be nice too.