### PR TITLE
Fix cublas include error

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -142,6 +142,8 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/lib
 
 RUN mv /opt/conda/envs/rapids/include/dmlc/ /opt/conda/envs/rapids/include/dmlc-OFF
 
+ENV CPLUS_INCLUDE_PATH="/usr/local/cuda-10.2/include"
+
 ENV NCCL_ROOT=/opt/conda/envs/rapids
 ENV PARALLEL_LEVEL=${PARALLEL_LEVEL}
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -100,6 +100,9 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/lib
 
 {# Remove dmlc that is leftover from prior xgboost install #}
 RUN mv /opt/conda/envs/rapids/include/dmlc/ /opt/conda/envs/rapids/include/dmlc-OFF
+
+{# This ENV var solves the missing cublas_v2.h error that occurs on centos-cuda10.1 images. #}
+ENV CPLUS_INCLUDE_PATH="/usr/local/cuda-10.2/include"
 {% endif %}
 
 {# xgboost build will not find nccl in the conda env without this env var #}


### PR DESCRIPTION
As seen in the screenshot below, `nvidia/cuda:10.1-devel-centos7` images have the `cublas_v2.h` files in the `/usr/local/cuda-10.2/include` folder instead of `/usr/local/cuda-10.1/include`. This causes "missing cublas_v2.h" errors in our `devel` build Jenkins jobs [as shown here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel/120/).

After reporting this to Jesus Alvarez, maintainer of the `nvidia/cuda` images, he mentioned that this was intentional and pointed me to the [explanation shown here](https://gitlab.com/nvidia/container-images/cuda/-/issues/88#note_411485001).

As a result, our images need to be patched with the changes in this PR to get the `centos-devel` builds working again.

![image](https://user-images.githubusercontent.com/7400326/92971238-1aa70000-f44e-11ea-9079-552a8e531847.png)


These changes were tested locally and confirmed working.