### PR TITLE
Move conda activate command in entrypoint

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -13,13 +13,13 @@ export PATH=$PATH:/home/rapids/bin
 export supkg="su-exec"
 chown rapids:rapids $HOME
 
-# Source "source" file if it exists
-SRC_FILE="/opt/docker/bin/entrypoint_source"
-[ -f "${SRC_FILE}" ] && source "${SRC_FILE}"
-
 # Activate the `rapids` conda environment.
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
+
+# Source "source" file if it exists
+SRC_FILE="/opt/docker/bin/entrypoint_source"
+[ -f "${SRC_FILE}" ] && source "${SRC_FILE}"
 
 # Run whatever the user wants.
 exec /opt/conda/bin/$supkg rapids "$@"


### PR DESCRIPTION
This PR moves the `conda activate` command in `entrypoint.sh` above the call to `/opt/docker/bin/entrypoint_source`. This is because some of the commands in `/opt/docker/bin/entrypoint_source` depend on the conda environment (like in [runtime_devel.sh](https://github.com/rapidsai/docker/blob/branch-0.16/context/source_entrypoints/runtime_devel.sh)).

This will resolve a bug where the `jupyter-lab` server does not start automatically in `runtime`/`devel` images.