### PR TITLE
Run jupyter-lab server as rapids user

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -22,4 +22,4 @@ SRC_FILE="/opt/docker/bin/entrypoint_source"
 [ -f "${SRC_FILE}" ] && source "${SRC_FILE}"
 
 # Run whatever the user wants.
-exec /opt/conda/bin/$supkg rapids "$@"
+exec /opt/conda/bin/$supkg $USER "$@"

--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -2,14 +2,14 @@
 
 # Run Jupyter in foreground if $JUPYTER_FG is set
 if [[ "${JUPYTER_FG}" == "true" ]]; then
-   jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
+   /opt/conda/bin/$supkg $USER bash -c "jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''"
    exit 0
 else
-   nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
+   /opt/conda/bin/$supkg $USER bash -c "nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &"
 
-   echo "Notebook server successfully started, a JupyterLab instance has been executed!"
-   echo "Make local folders visible by volume mounting to /rapids/notebook"
-   echo "To access visit http://localhost:8888 on your host machine."
-   echo 'Ensure the following arguments to "docker run" are added to expose the server ports to your host machine:
+   echo "A JupyterLab server has been started!"
+   echo "To access it, visit http://localhost:8888 on your host machine."
+   echo 'Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
       -p 8888:8888 -p 8787:8787 -p 8786:8786'
+   echo "Make local folders visible by bind mounting to /rapids/notebooks/host"
 fi


### PR DESCRIPTION
This PR ensures that the `jupyter-lab` server is run as the new `rapids` user. This is so that any new notebooks made from the Jupyter web dashboard are owned by the `rapids` user instead of the `root` user. This is useful for bind mounts used with the Jupyter-lab server so that files on the host machine aren't owned by `root`.

Additionally, this PR makes some tweaks to the output that is presented to users when running `runtime` & `devel` containers.

Specifically, it instructs users to bind mount to `/rapids/notebooks/host` instead of `/rapids/notebook`. The correct path is `/rapids/notebooks`, not `/rapids/notebook`. The `host` suffix was added because if users mount to `/rapids/notebooks`, then all of the existing RAPIDS notebooks are deleted. By mounting to `/rapids/notebooks/host`, the existing notebooks are retained and any notebooks mounted from bind mount can be found in the `host` subdirectory of `/rapids/notebooks`