### PR TITLE
Update passwordless sudo for rapids user

### DIFF
--- a/context/create_user.sh
+++ b/context/create_user.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -e
 
-# give sudo permission for rapids user to run apt/yum (user creation is postponed
+# give sudo permission for rapids user (user creation is postponed
 # to the entrypoint, so we can create a user with the same id as the host)
-if cat /etc/os-release | grep centos > /dev/null; then
-  PKG_MGR="yum";
-else
-  PKG_MGR="apt";
-fi
-echo "rapids ALL=NOPASSWD: /usr/bin/${PKG_MGR}" >> /etc/sudoers
+echo "rapids ALL=NOPASSWD: ALL" >> /etc/sudoers
 
 # Install su-exec
 SU_PKG="su-exec"


### PR DESCRIPTION
There have been some complaints that the new `rapids` user inside of the containers does not have the same privileges as the default `sudo` user that was previously being used. This PR updates the `sudoers` file to give the `rapids` user passwordless `sudo` access to all commands. Since the previous `root` user does not require any passwords for commands, this is the behavior that people have expected for the `rapids` user in our containers.