### PR TITLE
Update xgboost branch

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -104,7 +104,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.15 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v0.16 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -103,7 +103,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.15 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v0.16 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/settings.yaml
+++ b/settings.yaml
@@ -25,7 +25,7 @@ RAPIDS_LIBS:
   - name: xgboost
     update_submodules: no
     repo_url: https://github.com/rapidsai/xgboost.git
-    branch: rapids-v0.15
+    branch: rapids-v0.16
   - name: dask-xgboost
     repo_url: https://github.com/rapidsai/dask-xgboost.git
     branch: dask-cudf


### PR DESCRIPTION
This PR updates the xgboost branch to a new branch that has been updated to reflect the recent header-only changes in RMM ([link](https://github.com/rapidsai/rmm/pull/561)).