### PR TITLE
Add --no-install-recommends to apt-get installs

### DIFF
--- a/generated-dockerfiles/ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-base.Dockerfile
@@ -19,7 +19,7 @@ ARG RAPIDS_VER
 ENV RAPIDS_DIR=/rapids
 ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -39,7 +39,7 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gsfonts \
     sudo \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -20,7 +20,7 @@ ARG RAPIDS_VER
 ENV RAPIDS_DIR=/rapids
 ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 

--- a/templates/Base.dockerfile.j2
+++ b/templates/Base.dockerfile.j2
@@ -21,7 +21,7 @@ ENV RAPIDS_DIR=/rapids
 {% if "ubuntu" in os %}
 ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 {% endif %}

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -44,7 +44,7 @@ ENV RAPIDS_DIR=/rapids
 
 {% if "ubuntu" in os %}
 {# gsfonts is used to correctly render fonts in doxygen/graphviz diagrams #}
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gsfonts \
     sudo \
     && rm -rf /var/lib/apt/lists/*

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -22,7 +22,7 @@ ENV RAPIDS_DIR=/rapids
 {% if "ubuntu" in os %}
 ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 {% endif %}


### PR DESCRIPTION
This PR adds the `--no-install-recommends` flag to all of our `apt-get install` commands with the intention of trying to reduce our image sizes.