### PR TITLE
Remove RAPIDS_CHANNEL in 0.16

### DIFF
--- a/ci/axis/base-runtime.yaml
+++ b/ci/axis/base-runtime.yaml
@@ -12,9 +12,6 @@ IMAGE_TYPE:
 RAPIDS_VER:
   - 0.16
 
-RAPIDS_CHANNEL:
-  - rapidsai-nightly
-
 CUDA_VER:
   - 11.0
   - 10.2
@@ -31,8 +28,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.16
-    RAPIDS_CHANNEL: rapidsai
-  - BUILD_IMAGE: rapidsai/rapidsai
-    RAPIDS_CHANNEL: rapidsai-nightly
-  - BUILD_IMAGE: rapidsai/rapidsai-nightly
-    RAPIDS_CHANNEL: rapidsai
+    BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/devel.yaml
+++ b/ci/axis/devel.yaml
@@ -11,9 +11,6 @@ IMAGE_TYPE:
 RAPIDS_VER:
   - 0.16
 
-RAPIDS_CHANNEL:
-  - rapidsai-nightly
-
 CUDA_VER:
   - 11.0
   - 10.2
@@ -30,8 +27,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.16
-    RAPIDS_CHANNEL: rapidsai
-  - BUILD_IMAGE: rapidsai/rapidsai-dev
-    RAPIDS_CHANNEL: rapidsai-nightly
-  - BUILD_IMAGE: rapidsai/rapidsai-dev-nightly
-    RAPIDS_CHANNEL: rapidsai
+    BUILD_IMAGE: rapidsai/rapidsai-dev

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -52,13 +52,6 @@ else
   BUILD_ARGS="${BUILD_ARGS} --build-arg RAPIDS_VER=${RAPIDS_VER}"
   BUILD_TAG="${RAPIDS_VER}-${BUILD_TAG}" #pre-prend version number
 fi
-# Check if RAPIDS_CHANNEL is set
-if [ -z "$RAPIDS_CHANNEL" ] ; then
-  echo "RAPIDS_CHANNEL is not set, skipping..."
-else
-  echo "RAPIDS_CHANNEL is set to '$RAPIDS_CHANNEL', adding to build args..."
-  BUILD_ARGS="${BUILD_ARGS} --build-arg RAPIDS_CHANNEL=${RAPIDS_CHANNEL}"
-fi
 
 # Ouput build config
 gpuci_logger "Build config info..."


### PR DESCRIPTION
Similarly to #175, this PR removes the `RAPIDS_CHANNEL` axis entries since they are not currently being used.