### PR TITLE
Remove dask-xgboost (branch-0.16)

### DIFF
--- a/dockerhub-readme/Dockerhub_rapidsai-dev-nightly.md
+++ b/dockerhub-readme/Dockerhub_rapidsai-dev-nightly.md
@@ -20,7 +20,7 @@ Unlike the Docker images in [rapidsai/rapidsai-nightly](https://hub.docker.com/r
 
 Versions of libraries included in the `0.16` images:
 - `cuDF` [v0.16.0a](https://github.com/rapidsai/cudf), `cuML` [v0.16.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.16.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.16.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.16.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.16.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.16.0a](https://github.com/rapidsai/cuxfilter)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
 

--- a/dockerhub-readme/Dockerhub_rapidsai-nightly.md
+++ b/dockerhub-readme/Dockerhub_rapidsai-nightly.md
@@ -18,7 +18,7 @@ The `rapidsai/rapidsai-nightly` repo contains nightly docker builds of the lates
 
 Versions of libraries included in the `0.16` images:
 - `cuDF` [v0.16.0a](https://github.com/rapidsai/cudf), `cuML` [v0.16.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.16.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.16.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.16.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.16.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.16.0a](https://github.com/rapidsai/cuxfilter)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -130,10 +130,6 @@ RUN cd ${RAPIDS_DIR} \
   && cd ${RAPIDS_DIR} \
   && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
   && cd dask-cuda \
-  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
-  && cd ${RAPIDS_DIR} \
-  && git clone -b dask-cudf --depth 1 --single-branch https://github.com/rapidsai/dask-xgboost.git \
-  && cd dask-xgboost \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 
   
 
@@ -214,11 +210,6 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi
-
-RUN cd ${RAPIDS_DIR}/dask-xgboost && \
-  source activate rapids && \
-  ccache -s && \
-  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -129,10 +129,6 @@ RUN cd ${RAPIDS_DIR} \
   && cd ${RAPIDS_DIR} \
   && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
   && cd dask-cuda \
-  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
-  && cd ${RAPIDS_DIR} \
-  && git clone -b dask-cudf --depth 1 --single-branch https://github.com/rapidsai/dask-xgboost.git \
-  && cd dask-xgboost \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 
   
 
@@ -209,11 +205,6 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi
-
-RUN cd ${RAPIDS_DIR}/dask-xgboost && \
-  source activate rapids && \
-  ccache -s && \
-  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/settings.yaml
+++ b/settings.yaml
@@ -26,8 +26,5 @@ RAPIDS_LIBS:
     update_submodules: no
     repo_url: https://github.com/rapidsai/xgboost.git
     branch: rapids-v0.16
-  - name: dask-xgboost
-    repo_url: https://github.com/rapidsai/dask-xgboost.git
-    branch: dask-cudf
   - name: dask-cuda
     repo_url: https://github.com/rapidsai/dask-cuda.git

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -154,7 +154,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   {% elif lib.name == "cuml" %}
   ./build.sh --allgpuarch libcuml cuml prims
 
-  {% elif lib.name == "dask-cuda" or lib.name == "dask-xgboost" %}
+  {% elif lib.name == "dask-cuda"%}
   python setup.py install
 
   {% else %}


### PR DESCRIPTION
As indicated by Ray in [this PR](https://github.com/rapidsai/integration/pull/143), `dask-xgboost` was deprecated in `0.15` and should be removed in `0.16`. This PR removes `dask-xgboost` from the Docker `devel` images.