### PR TITLE
BUG skip cugraph benchmark notebooks

### DIFF
--- a/context/test.sh
+++ b/context/test.sh
@@ -7,7 +7,7 @@ NOTEBOOKS_DIR=${RAPIDS_DIR}/notebooks
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="cuml_benchmarks.ipynb"
+SKIPNBS="cuml_benchmarks.ipynb uvm.ipynb bfs_benchmark.ipynb louvain_benchmark.ipynb pagerank_benchmark.ipynb sssp_benchmark.ipynb release.ipynb nx_cugraph_bc_benchmarking.ipynb"
 
 ## Check env
 env


### PR DESCRIPTION
Skip the cugraph benchmarking notebooks.  These notebooks can take half a day to run and are really on-demand notebooks and not for testing