### PR TITLE
Update CI axis to build 0.17 nightlies

### DIFF
--- a/ci/axis/base-runtime.yaml
+++ b/ci/axis/base-runtime.yaml
@@ -11,6 +11,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.16
+  - 0.17
 
 CUDA_VER:
   - 11.0
@@ -28,4 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.16
+    BUILD_IMAGE: rapidsai/rapidsai
+  - RAPIDS_VER: 0.17
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/devel.yaml
+++ b/ci/axis/devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.16
+  - 0.17
 
 CUDA_VER:
   - 11.0
@@ -27,4 +28,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.16
+    BUILD_IMAGE: rapidsai/rapidsai-dev
+  - RAPIDS_VER: 0.17
     BUILD_IMAGE: rapidsai/rapidsai-dev


### PR DESCRIPTION
This PR updates the CI axis to build the `0.17` nightlies.