### PR TITLE
[REVIEW] FIX Add SDR notebooks to skip list

### DIFF
--- a/context/test.sh
+++ b/context/test.sh
@@ -7,7 +7,8 @@ NOTEBOOKS_DIR=${RAPIDS_DIR}/notebooks
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="cuml_benchmarks.ipynb uvm.ipynb bfs_benchmark.ipynb louvain_benchmark.ipynb pagerank_benchmark.ipynb sssp_benchmark.ipynb release.ipynb nx_cugraph_bc_benchmarking.ipynb"
+SKIPNBS="cuml_benchmarks.ipynb uvm.ipynb bfs_benchmark.ipynb louvain_benchmark.ipynb pagerank_benchmark.ipynb sssp_benchmark.ipynb 
+         release.ipynb nx_cugraph_bc_benchmarking.ipynb sdr_integration.ipynb sdr_wfm_demod.ipynb"
 
 ## Check env
 env


### PR DESCRIPTION
These notebooks are failing in CI. cusignal devs have brought it to our attention that SDR notebooks require specific hardware and have recommended that we skip these specific notebooks.