### PR TITLE
Use unique temp files in nbtest.sh

### DIFF
--- a/context/nbtest.sh
+++ b/context/nbtest.sh
@@ -27,16 +27,14 @@ for nb in $*; do
     NBFILENAME=$1
     NBNAME=${NBFILENAME%.*}
     NBNAME=${NBNAME##*/}
-    NBTESTSCRIPT=/tmp/${NBNAME}-test.py
+    NBTESTSCRIPT=$(mktemp --suffix=.py)
     shift
 
     echo --------------------------------------------------------------------------------
     echo STARTING: ${NBNAME}
     echo --------------------------------------------------------------------------------
-    jupyter nbconvert --to script ${NBFILENAME} --output /tmp/${NBNAME}-test
-    echo "${MAGIC_OVERRIDE_CODE}" > /tmp/tmpfile
-    cat ${NBTESTSCRIPT} >> /tmp/tmpfile
-    mv /tmp/tmpfile ${NBTESTSCRIPT}
+    echo "${MAGIC_OVERRIDE_CODE}" > "${NBTESTSCRIPT}"
+    jupyter nbconvert --to script "${NBFILENAME}" --stdout >> "${NBTESTSCRIPT}"
 
     echo "Running \"ipython ${NO_COLORS} ${NBTESTSCRIPT}\" on $(date)"
     echo
@@ -45,6 +43,7 @@ for nb in $*; do
     echo EXIT CODE: ${NBEXITCODE}
     echo
     EXITCODE=$((EXITCODE | ${NBEXITCODE}))
+    rm -f "${NBTESTSCRIPT}"
 done
 
 exit ${EXITCODE}


### PR DESCRIPTION
This PR ensures that the temp files in `nbtest.sh` are unique.

This is important for CI since the `remote-docker-plugin` volume mounts the `/tmp` directory. This means that during matrix runs (which run in parallel), the `/tmp` directory is shared across all individual matrix jobs.

Additionally, the `mktemp` command also respects the `TMPDIR` environment variable, which is useful for our common `TMPDIR=${WORKSPACE}/tmp` commands.

This PR can quickly be tested by copying and pasting the updated `context/nbtest.sh` file into `/rapids/utils/nbtest.sh` on a `runtime` or `devel` container and then running `/test.sh`.