### PR TITLE
Add gpuci_conda_retries

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -51,12 +51,12 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*"
 
@@ -69,7 +69,7 @@ RUN source activate rapids \
 
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -36,7 +36,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -53,12 +53,12 @@ RUN source activate rapids \
   && conda info \
   && conda config --show-sources \
   && conda list --show-channel-urls
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*"
 
@@ -71,7 +71,7 @@ RUN source activate rapids \
 
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -36,7 +36,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -63,12 +63,12 @@ between packages. #}
 {% include 'partials/env_debug.dockerfile.j2' %}
 
 {# Install rapids-build-env and rapids-doc-env from conda meta-pkg #}
-RUN gpuci_retry conda install -y -n rapids \
+RUN gpuci_conda_retry install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*"
 

--- a/templates/partials/install_notebooks.dockerfile.j2
+++ b/templates/partials/install_notebooks.dockerfile.j2
@@ -3,7 +3,7 @@
 {# Install the rapids-notebook-env meta-pkg #}
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
 {# Install jupyter lab stuff #}


### PR DESCRIPTION
This PR adds more `gpuci_conda_retry`s throughout the Dockerfile to try to prevent more `conda` errors.

I replaced some `conda remove` commands with `gpuci_conda_retry remove` due to this issue https://github.com/rapidsai/gpuci-tools/issues/14 that I opened which I now suspect was due to `conda remove` not using `gpuci_conda_retry remove`.