### PR TITLE
Update Blazing DockerHub repo name

### DIFF
--- a/blazing-dev/ci/axis/devel.yaml
+++ b/blazing-dev/ci/axis/devel.yaml
@@ -1,6 +1,6 @@
 BUILD_IMAGE:
-  - rapidsai/blazingdb-dev
-  - rapidsai/blazingdb-dev-nightly
+  - rapidsai/blazingsql-dev
+  - rapidsai/blazingsql-dev-nightly
 
 FROM_IMAGE:
   - rapidsai/rapidsai-dev-nightly


### PR DESCRIPTION
This PR updates the image name used for Blazing images from `rapidsai/blazingdb-dev` and `rapidsai/blazingdb-dev-nightly` to `rapidsai/blazingsql-dev` and `rapidsai/blazingsql-dev-nightly` respectively.