### PR TITLE
Update ci axis excludes for Blazing images

### DIFF
--- a/blazing-dev/ci/axis/devel.yaml
+++ b/blazing-dev/ci/axis/devel.yaml
@@ -27,4 +27,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.16
-    BUILD_IMAGE: rapidsai/blazingdb-dev
+    BUILD_IMAGE: rapidsai/blazingsql-dev


### PR DESCRIPTION
This PR updates the `excludes` yaml key for Blazing images. This should've been included in #190 