### PR TITLE
Remove dmlc workaround for centos devel images

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -132,8 +132,6 @@ RUN cd ${RAPIDS_DIR} \
 ENV LD_LIBRARY_PATH_PREBUILD=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs
 
-RUN mv /opt/conda/envs/rapids/include/dmlc/ /opt/conda/envs/rapids/include/dmlc-OFF
-
 ENV NCCL_ROOT=/opt/conda/envs/rapids
 ENV PARALLEL_LEVEL=${PARALLEL_LEVEL}
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -92,9 +92,6 @@ RUN cd ${RAPIDS_DIR} \
 This will need to be removed later since it causes problems with certain runtime libs (numba.cuda) #}
 ENV LD_LIBRARY_PATH_PREBUILD=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs
-
-{# Remove dmlc that is leftover from prior xgboost install #}
-RUN mv /opt/conda/envs/rapids/include/dmlc/ /opt/conda/envs/rapids/include/dmlc-OFF
 {% endif %}
 
 {# xgboost build will not find nccl in the conda env without this env var #}


### PR DESCRIPTION
This PR reverts a temporary workaround that was implemented in #109 due to an `xgboost` build issue. The issue was likely fixed upstream since my local builds built successfully without any other action required.


**Note:** This should be merged into the `0.17` branch once it's created. Keeping it as a draft until then to prevent an accidental merge into the `0.16` branch.