### PR TITLE
Add Blazing 0.17 images to axis

### DIFF
--- a/blazing-dev/ci/axis/devel.yaml
+++ b/blazing-dev/ci/axis/devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.16
+  - 0.17
 
 CUDA_VER:
   - 11.0
@@ -27,4 +28,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.16
+    BUILD_IMAGE: rapidsai/blazingsql-dev
+  - RAPIDS_VER: 0.17
     BUILD_IMAGE: rapidsai/blazingsql-dev


### PR DESCRIPTION
This PR adds blazing version 0.17 images to the CI axis.