### PR TITLE
Update Blazing Axis - FROM_IMAGE

### DIFF
--- a/blazing-dev/ci/axis/devel.yaml
+++ b/blazing-dev/ci/axis/devel.yaml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
   - rapidsai/blazingsql-dev-nightly
 
 FROM_IMAGE:
-  - rapidsai/rapidsai-dev-nightly
+  - rapidsai/rapidsai-dev
 
 IMAGE_TYPE:
   - devel


### PR DESCRIPTION
This PR updates the Blazing axis to use `rapidsai/rapidsai-dev` instead of `rapidsai/rapidsai-dev-nightly` as the `FROM_IMAGE` for the `0.16` release.