### PR TITLE
FIX Add patch for CVE-2020-8116

### DIFF
--- a/generated-dockerfiles/centos7-base.Dockerfile
+++ b/generated-dockerfiles/centos7-base.Dockerfile
@@ -32,6 +32,10 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -62,6 +62,10 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -34,6 +34,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/generated-dockerfiles/ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-base.Dockerfile
@@ -32,6 +32,10 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -64,6 +64,10 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -34,6 +34,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/templates/Base.dockerfile.j2
+++ b/templates/Base.dockerfile.j2
@@ -36,6 +36,9 @@ COPY libm.so.6 ${GCC7_DIR}/lib64
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+{# Patch for CVEs #}
+{% include 'partials/patch.dockerfile.j2' %}
+
 {# Run common commands #}
 COPY packages.sh /opt/docker/bin/
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -72,6 +72,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*"
 
+{# Patch for CVEs #}
+{% include 'partials/patch.dockerfile.j2' %}
+
 {% include 'partials/env_debug.dockerfile.j2' %}
 
 {% include 'partials/install_notebooks.dockerfile.j2' %}

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -38,6 +38,9 @@ COPY libm.so.6 ${GCC7_DIR}/lib64
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+{# Patch for CVEs #}
+{% include 'partials/patch.dockerfile.j2' %}
+
 {% include 'partials/install_notebooks.dockerfile.j2' %}
 
 COPY packages.sh /opt/docker/bin/

--- a/templates/partials/patch.dockerfile.j2
+++ b/templates/partials/patch.dockerfile.j2
@@ -1,0 +1,6 @@
+{# This partial is used to install patches to resolve known CVEs #}
+
+{# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
+RUN source activate rapids \
+    && cd /opt/conda/envs/rapids/lib/node_modules/npm \
+    && NODE_PATH=/opt/conda/envs/rapids/lib/node_modules/npm/node_modules npm install dot-prop@4.2.1


### PR DESCRIPTION
Follows #199 - Updates `dot-prop` in the `rapids` conda env to `4.2.1` which is patched for this CVE