### PR TITLE
Add BUILD_BRANCH build argument for library clones (hotfix)

### DIFF
--- a/blazing-dev/ci/gpuci/run.sh
+++ b/blazing-dev/ci/gpuci/run.sh
@@ -35,7 +35,7 @@ gpuci_logger ">>>> END Dockerfile <<<<"
 # Get build info ready
 gpuci_logger "Preparing build config..."
 BUILD_TAG="cuda${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
-BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER"
+BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER --build-arg BUILD_BRANCH=$BUILD_BRANCH"
 # Check if PYTHON_VER is set
 if [ -z "$PYTHON_VER" ] ; then
   echo "PYTHON_VER is not set, skipping..."

--- a/blazing-dev/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/blazing-dev/generated-dockerfiles/centos7-devel.Dockerfile
@@ -15,6 +15,9 @@ ARG FROM_IMAGE=rapidsai/rapidsai-dev-nightly
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
 ENV BLAZING_DIR=/blazing
 
 RUN gpuci_conda_retry install -y -n rapids \
@@ -37,7 +40,7 @@ ENV CUDF_HOME=/rapids/cudf
 # Clone, build, install. Note: This uses the current default branch instead of main.
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b branch-${RAPIDS_VER} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
 
 # Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 # not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/blazing-dev/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/blazing-dev/generated-dockerfiles/centos7-devel.Dockerfile
@@ -37,7 +37,7 @@ ENV CUDF_HOME=/rapids/cudf
 # Clone, build, install. Note: This uses the current default branch instead of main.
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b branch-0.16 https://github.com/BlazingDB/blazingsql.git
+    && git clone -b branch-${RAPIDS_VER} https://github.com/BlazingDB/blazingsql.git
 
 # Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 # not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/blazing-dev/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/blazing-dev/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -15,6 +15,9 @@ ARG FROM_IMAGE=rapidsai/rapidsai-dev-nightly
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
 ENV BLAZING_DIR=/blazing
 
 RUN gpuci_conda_retry install -y -n rapids \
@@ -37,7 +40,7 @@ ENV CUDF_HOME=/rapids/cudf
 # Clone, build, install. Note: This uses the current default branch instead of main.
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b branch-${RAPIDS_VER} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
 
 # Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 # not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/blazing-dev/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/blazing-dev/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -37,7 +37,7 @@ ENV CUDF_HOME=/rapids/cudf
 # Clone, build, install. Note: This uses the current default branch instead of main.
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b branch-0.16 https://github.com/BlazingDB/blazingsql.git
+    && git clone -b branch-${RAPIDS_VER} https://github.com/BlazingDB/blazingsql.git
 
 # Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 # not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/blazing-dev/templates/Devel.dockerfile.j2
+++ b/blazing-dev/templates/Devel.dockerfile.j2
@@ -15,6 +15,9 @@ ARG FROM_IMAGE=rapidsai/rapidsai-dev-nightly
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
 
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
 {# Additions for BlazingSQL, change the default WORKDIR to run BlazingSQL NBs by default #}
 ENV BLAZING_DIR=/blazing
 {% include 'partials/clone_and_build_blazing.dockerfile.j2' %}

--- a/blazing-dev/templates/partials/clone_and_build_blazing.dockerfile.j2
+++ b/blazing-dev/templates/partials/clone_and_build_blazing.dockerfile.j2
@@ -21,7 +21,7 @@ ENV CUDF_HOME=/rapids/cudf
 # Clone, build, install. Note: This uses the current default branch instead of main.
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b branch-${RAPIDS_VER} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
 
 # Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 # not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/blazing-dev/templates/partials/clone_and_build_blazing.dockerfile.j2
+++ b/blazing-dev/templates/partials/clone_and_build_blazing.dockerfile.j2
@@ -21,7 +21,7 @@ ENV CUDF_HOME=/rapids/cudf
 # Clone, build, install. Note: This uses the current default branch instead of main.
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b branch-{{ DEFAULT_RAPIDS_VERSION }} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b branch-${RAPIDS_VER} https://github.com/BlazingDB/blazingsql.git
 
 # Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 # not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -35,7 +35,7 @@ gpuci_logger ">>>> END Dockerfile <<<<"
 # Get build info ready
 gpuci_logger "Preparing build config..."
 BUILD_TAG="cuda${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
-BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER"
+BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER --build-arg BUILD_BRANCH=$BUILD_BRANCH"
 # Check if PYTHON_VER is set
 if [ -z "$PYTHON_VER" ] ; then
   echo "PYTHON_VER is not set, skipping..."

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -23,8 +23,6 @@ def load_settings():
         settings = yaml.load(settings_file, Loader=yaml.FullLoader)
     # Set default RAPIDS_LIBS values
     for lib in settings["RAPIDS_LIBS"]:
-        if "branch" not in lib.keys():
-            lib["branch"] = f'branch-{settings["DEFAULT_RAPIDS_VERSION"]}'
         if "update_submodules" not in lib.keys():
             lib["update_submodules"] = True
     return settings

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -95,11 +95,11 @@ EXPOSE 8786
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
   && cd cudf \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
@@ -107,27 +107,27 @@ RUN cd ${RAPIDS_DIR} \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
   && cd cuxfilter \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
   && cd cuspatial \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
   && cd cugraph \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
   && cd dask-cuda \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 
   

--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -34,6 +34,7 @@ RUN ccache -s
 
 ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ARG PYTHON_VER
 
@@ -82,7 +83,7 @@ RUN source activate rapids \
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
   && cd notebooks \
   && git submodule update --init --remote --no-single-branch --depth 1
 
@@ -95,11 +96,11 @@ EXPOSE 8786
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
   && cd cudf \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
@@ -107,27 +108,27 @@ RUN cd ${RAPIDS_DIR} \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
   && cd cuxfilter \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
   && cd cuspatial \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
   && cd cugraph \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
   && cd dask-cuda \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 
   

--- a/generated-dockerfiles/centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/centos7-runtime.Dockerfile
@@ -16,6 +16,7 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
 
@@ -49,7 +50,7 @@ RUN source activate rapids \
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
   && cd notebooks \
   && git submodule update --init --remote --no-single-branch --depth 1
 

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -97,11 +97,11 @@ EXPOSE 8786
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
   && cd cudf \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
@@ -109,27 +109,27 @@ RUN cd ${RAPIDS_DIR} \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
   && cd cuxfilter \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
   && cd cuspatial \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
   && cd cugraph \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-0.16 --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
   && cd dask-cuda \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 
   

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -34,6 +34,7 @@ RUN ccache -s
 
 ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ARG PYTHON_VER
 
@@ -84,7 +85,7 @@ RUN source activate rapids \
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
   && cd notebooks \
   && git submodule update --init --remote --no-single-branch --depth 1
 
@@ -97,11 +98,11 @@ EXPOSE 8786
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cudf.git \
   && cd cudf \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuml.git \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
@@ -109,27 +110,27 @@ RUN cd ${RAPIDS_DIR} \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/rmm.git \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuxfilter \
   && cd cuxfilter \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
   && cd cuspatial \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
   && cd cugraph \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/dask-cuda.git \
   && cd dask-cuda \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 
   

--- a/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-runtime.Dockerfile
@@ -16,6 +16,7 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
 ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
@@ -49,7 +50,7 @@ RUN source activate rapids \
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
   && cd notebooks \
   && git submodule update --init --remote --no-single-branch --depth 1
 

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -83,8 +83,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 {# Clone RAPIDS libraries #}
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-{% for lib in RAPIDS_LIBS | sort(attribute="update_submodules,branch") %}
-  && git clone -b {{ lib.branch }} --depth 1 --single-branch {{ lib.repo_url }} \
+{% for lib in RAPIDS_LIBS | sort(attribute="update_submodules") %}
+  && git clone -b {{ lib.branch | default('branch-${RAPIDS_VER}') }} --depth 1 --single-branch {{ lib.repo_url }} \
   && cd {{ lib.name }} \
   && git submodule update --init{{ ' --remote' if lib.update_submodules }} --recursive --no-single-branch --depth 1 {{ "\\" if not loop.last }}
   {{ "&& cd ${RAPIDS_DIR} \\" if not loop.last }}

--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -37,6 +37,7 @@ RUN ccache -s
 {# devel environment config args #}
 ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ARG PYTHON_VER
 
@@ -84,7 +85,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
 {% for lib in RAPIDS_LIBS | sort(attribute="update_submodules") %}
-  && git clone -b {{ lib.branch | default('branch-${RAPIDS_VER}') }} --depth 1 --single-branch {{ lib.repo_url }} \
+  && git clone -b {{ lib.branch | default('${BUILD_BRANCH}') }} --depth 1 --single-branch {{ lib.repo_url }} \
   && cd {{ lib.name }} \
   && git submodule update --init{{ ' --remote' if lib.update_submodules }} --recursive --no-single-branch --depth 1 {{ "\\" if not loop.last }}
   {{ "&& cd ${RAPIDS_DIR} \\" if not loop.last }}

--- a/templates/Runtime.dockerfile.j2
+++ b/templates/Runtime.dockerfile.j2
@@ -17,6 +17,7 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON
 {# base/runtime install specs #}
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
 {% if "ubuntu" in os %}

--- a/templates/partials/install_notebooks.dockerfile.j2
+++ b/templates/partials/install_notebooks.dockerfile.j2
@@ -15,7 +15,7 @@ RUN source activate rapids \
 {# Install notebooks repo #}
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
+  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
   && cd notebooks \
   && git submodule update --init --remote --no-single-branch --depth 1
 


### PR DESCRIPTION
This PR adds a `BUILD_BRANCH` build argument so that the RAPIDS libraries' `git clone`s use the same branch as the Docker repo.

---

This PR is the same as #207 except that it targets the `main` branch.