### PR TITLE
Temporarily remove cuspatial

### DIFF
--- a/generated-dockerfiles/centos7-devel.Dockerfile
+++ b/generated-dockerfiles/centos7-devel.Dockerfile
@@ -120,10 +120,6 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuxfilter \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
-  && cd cuspatial \
-  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
-  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
   && cd cugraph \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -160,13 +156,6 @@ RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
   ./build.sh
-
-RUN cd ${RAPIDS_DIR}/cuspatial && \
-  source activate rapids && \
-  ccache -s && \
-  export CUSPATIAL_HOME="$PWD" && \
-  export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \

--- a/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/ubuntu18.04-devel.Dockerfile
@@ -122,10 +122,6 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuxfilter \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cuspatial.git \
-  && cd cuspatial \
-  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
-  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cugraph.git \
   && cd cugraph \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -160,13 +156,6 @@ RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
   ./build.sh
-
-RUN cd ${RAPIDS_DIR}/cuspatial && \
-  source activate rapids && \
-  ccache -s && \
-  export CUSPATIAL_HOME="$PWD" && \
-  export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \

--- a/settings.yaml
+++ b/settings.yaml
@@ -15,8 +15,8 @@ RAPIDS_LIBS:
     repo_url: https://github.com/rapidsai/cusignal.git
   - name: cuxfilter
     repo_url: https://github.com/rapidsai/cuxfilter
-  - name: cuspatial
-    repo_url: https://github.com/rapidsai/cuspatial.git
+  # - name: cuspatial
+  #   repo_url: https://github.com/rapidsai/cuspatial.git
   - name: cuml
     repo_url: https://github.com/rapidsai/cuml.git
     update_submodules: no


### PR DESCRIPTION
This PR temporarily removes `cuspatial` from our `devel` images due to some outstanding issues that they're working through.