### PR TITLE
Add 0.18 imgs to axes

### DIFF
--- a/blazing-dev/ci/axis/devel.yaml
+++ b/blazing-dev/ci/axis/devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0
@@ -27,4 +28,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.17
+    BUILD_IMAGE: rapidsai/blazingsql-dev
+  - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/blazingsql-dev

--- a/ci/axis/base-runtime.yaml
+++ b/ci/axis/base-runtime.yaml
@@ -11,6 +11,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0
@@ -28,4 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.17
+    BUILD_IMAGE: rapidsai/rapidsai
+  - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/devel.yaml
+++ b/ci/axis/devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0
@@ -27,4 +28,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.17
+    BUILD_IMAGE: rapidsai/rapidsai-dev
+  - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-dev


### PR DESCRIPTION
This PR adds the `0.18` images to our axes so we can start getting `0.18` nightlies out.