### PR TITLE
Add Blazing notebooks to devel images

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -20,6 +20,12 @@ ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV BLAZING_DIR=/blazing
 
+RUN mkdir -p ${BLAZING_DIR} \
+    && cd ${BLAZING_DIR} \
+    && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
+
+COPY test.sh /
+
 RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
       "blazingsql-build-env=${RAPIDS_VER}*" \
       "rapids-build-env=${RAPIDS_VER}*" \
@@ -31,25 +37,14 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-# Clone, build, install
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
 
-# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
-# not needed when using the nvidia runtime with "docker run" since the nvidia
-# runtime also installs libcuda to a system location that client builds often
-# find.
 
-# Explicitly add the cuda runtime dir for the Blazing build, then remove once
-# build is done to keep the original LD_LIBRARY_PATH intact.
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat
 
-# Remove libm added for older build compatibility, since this is not compatible
-# with libjvm needed by BlazingSQL
-# FIXME: this libm should no longer be needed anywhere, so consider removing it
-# in the RAPIDS images
 RUN rm -f ${GCC7_DIR}/lib64/libm.so.6
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
@@ -21,12 +21,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 ENV BLAZING_DIR=/blazing
 
 
-# Clone, build, install
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-# Update the test script to include BlazingSQL notebooks
 COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -20,6 +20,12 @@ ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV BLAZING_DIR=/blazing
 
+RUN mkdir -p ${BLAZING_DIR} \
+    && cd ${BLAZING_DIR} \
+    && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
+
+COPY test.sh /
+
 RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
       "blazingsql-build-env=${RAPIDS_VER}*" \
       "rapids-build-env=${RAPIDS_VER}*" \
@@ -31,18 +37,11 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-# Clone, build, install
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
 
-# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
-# not needed when using the nvidia runtime with "docker run" since the nvidia
-# runtime also installs libcuda to a system location that client builds often
-# find.
 
-# Explicitly add the cuda runtime dir for the Blazing build, then remove once
-# build is done to keep the original LD_LIBRARY_PATH intact.
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat
 

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
@@ -21,12 +21,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 ENV BLAZING_DIR=/blazing
 
 
-# Clone, build, install
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-# Update the test script to include BlazingSQL notebooks
 COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 

--- a/templates/rapidsai/Devel.dockerfile.j2
+++ b/templates/rapidsai/Devel.dockerfile.j2
@@ -19,6 +19,8 @@ ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV BLAZING_DIR=/blazing
+{% include 'partials/clone_blazing_notebooks.dockerfile.j2' %}
+
 {% include 'partials/clone_and_build_blazing.dockerfile.j2' %}
 
 WORKDIR ${RAPIDS_DIR}

--- a/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
@@ -12,26 +12,26 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-# Clone, build, install
+{# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
 
-# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
-# not needed when using the nvidia runtime with "docker run" since the nvidia
-# runtime also installs libcuda to a system location that client builds often
-# find.
+{# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
+not needed when using the nvidia runtime with "docker run" since the nvidia
+runtime also installs libcuda to a system location that client builds often
+find. #}
 
-# Explicitly add the cuda runtime dir for the Blazing build, then remove once
-# build is done to keep the original LD_LIBRARY_PATH intact.
+{# Explicitly add the cuda runtime dir for the Blazing build, then remove once
+build is done to keep the original LD_LIBRARY_PATH intact. #}
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat
 
 {% if "centos" in os %}
-# Remove libm added for older build compatibility, since this is not compatible
-# with libjvm needed by BlazingSQL
-# FIXME: this libm should no longer be needed anywhere, so consider removing it
-# in the RAPIDS images
+{# Remove libm added for older build compatibility, since this is not compatible
+with libjvm needed by BlazingSQL
+FIXME: this libm should no longer be needed anywhere, so consider removing it
+in the RAPIDS images #}
 RUN rm -f ${GCC7_DIR}/lib64/libm.so.6
 {% endif %}
 

--- a/templates/rapidsai/partials/clone_blazing_notebooks.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_blazing_notebooks.dockerfile.j2
@@ -1,9 +1,9 @@
 {# This partial clones the "Welcome to BlazingSQL" repo containing example notebooks. #}
 
-# Clone, build, install
+{# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-# Update the test script to include BlazingSQL notebooks
+{# Update the test script to include BlazingSQL notebooks #}
 COPY test.sh /


### PR DESCRIPTION
This PR adds Blazing's notebooks to the `rapidsai` devel images since they were missing. It also switches some of the existing comments to use Jinja comments to prevent them from appearing in the final generated Dockerfiles. This matches the comment style of the rest of the repo.