### PR TITLE
Update ubuntu20 & centos8 exclusions

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -33,3 +33,11 @@ exclude:
     BUILD_IMAGE: rapidsai/rapidsai
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai
+  - CUDA_VER: 10.1
+    LINUX_VER: centos8
+  - CUDA_VER: 10.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2
+    LINUX_VER: centos8
+  - CUDA_VER: 10.2
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -31,3 +31,11 @@ exclude:
     BUILD_IMAGE: rapidsai/rapidsai-core
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-core
+  - CUDA_VER: 10.1
+    LINUX_VER: centos8
+  - CUDA_VER: 10.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2
+    LINUX_VER: centos8
+  - CUDA_VER: 10.2
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -32,3 +32,11 @@ exclude:
     BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-core-dev
+  - CUDA_VER: 10.1
+    LINUX_VER: centos8
+  - CUDA_VER: 10.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2
+    LINUX_VER: centos8
+  - CUDA_VER: 10.2
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -32,3 +32,11 @@ exclude:
     BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-dev
+  - CUDA_VER: 10.1
+    LINUX_VER: centos8
+  - CUDA_VER: 10.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2
+    LINUX_VER: centos8
+  - CUDA_VER: 10.2
+    LINUX_VER: ubuntu20.04


### PR DESCRIPTION
This PR updates the ubuntu20 and centos8 exclusions since they should not run on anything below CUDA 11.