### PR TITLE
FIX Add centos8 & ubuntu20.04 to axis

### DIFF
--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -20,7 +20,9 @@ CUDA_VER:
 LINUX_VER:
   - ubuntu16.04
   - ubuntu18.04
+  - ubuntu20.04
   - centos7
+  - centos8
 
 PYTHON_VER:
   - 3.7


### PR DESCRIPTION
Missing from the axis files in the new rapids-core files