### PR TITLE
Update axes & fix BUILD_BRANCH build argument

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -29,8 +29,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.17
-    BUILD_IMAGE: rapidsai/rapidsai
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -10,7 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -10,7 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -29,8 +29,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.17
-    BUILD_IMAGE: rapidsai/rapidsai-core
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-core
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -9,7 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -28,8 +28,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.17
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -9,7 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -28,8 +28,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.17
-    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-dev
   - CUDA_VER: 10.1

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -30,13 +30,21 @@ gpuci_logger ">>>> END Dockerfile <<<<"
 # Get build info ready
 gpuci_logger "Preparing build config..."
 BUILD_TAG="cuda${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
-BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER --build-arg BUILD_BRANCH=$BUILD_BRANCH"
+BUILD_ARGS="--squash \
+  --build-arg FROM_IMAGE=${FROM_IMAGE} \
+  --build-arg CUDA_VER=${CUDA_VER} \
+  --build-arg IMAGE_TYPE=${IMAGE_TYPE} \
+  --build-arg LINUX_VER=${LINUX_VER}"
+# Add BUILD_BRANCH arg for 'main' branch only
+if [ "${BUILD_BRANCH}" = "main" ]; then
+  BUILD_ARGS+=" --build-arg BUILD_BRANCH=${BUILD_BRANCH}"
+fi
 # Check if PYTHON_VER is set
 if [ -z "$PYTHON_VER" ] ; then
   echo "PYTHON_VER is not set, skipping..."
 else
   echo "PYTHON_VER is set to '$PYTHON_VER', adding to build args/tag..."
-  BUILD_ARGS="${BUILD_ARGS} --build-arg PYTHON_VER=${PYTHON_VER}"
+  BUILD_ARGS+=" --build-arg PYTHON_VER=${PYTHON_VER}"
   BUILD_TAG="${BUILD_TAG}-py${PYTHON_VER}"
 fi
 # Check if RAPIDS_VER is set
@@ -44,7 +52,7 @@ if [ -z "$RAPIDS_VER" ] ; then
   echo "RAPIDS_VER is not set, skipping..."
 else
   echo "RAPIDS_VER is set to '$RAPIDS_VER', adding to build args..."
-  BUILD_ARGS="${BUILD_ARGS} --build-arg RAPIDS_VER=${RAPIDS_VER}"
+  BUILD_ARGS+=" --build-arg RAPIDS_VER=${RAPIDS_VER}"
   BUILD_TAG="${RAPIDS_VER}-${BUILD_TAG}" #pre-prend version number
 fi
 


### PR DESCRIPTION
This PR includes the following changes:

- Updates the CI axes for `branch-0.18`
- Makes sure the `BUILD_BRANCH` build argument is only set when building the `main` branch. Otherwise, it will default to `branch-${RAPIDS_VER}` as shown [here](https://github.com/rapidsai/docker/blob/branch-0.18/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile#L18-L19) (where `RAPIDS_VER` comes from the [axes files](https://github.com/rapidsai/docker/blob/branch-0.18/ci/axis/rapidsai-devel.yaml#L11-L12)). This prevents an issue during burndown where stable and nightly images are being built simultaneously and both sets of images use the stable version as `BUILD_BRANCH` because of how our branching strategy is set up in this repo.