### PR TITLE
CLX templates and dockerfiles

### DIFF
--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -30,7 +30,7 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai
+    BUILD_IMAGE: rapidsai/rapidsai-clx
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -1,0 +1,41 @@
+BUILD_IMAGE:
+  - rapidsai/rapidsai-clx
+  - rapidsai/rapidsai-clx-nightly
+
+FROM_IMAGE:
+  - rapidsai/rapidsai-nightly
+
+IMAGE_TYPE:
+  - base
+  - runtime
+
+RAPIDS_VER:
+  - 0.18
+
+CUDA_VER:
+  - 11.0
+  - 10.2
+  - 10.1
+
+LINUX_VER:
+  - ubuntu16.04
+  - ubuntu18.04
+  - ubuntu20.04
+  - centos7
+  - centos8
+
+PYTHON_VER:
+  - 3.7
+  - 3.8
+
+exclude:
+  - RAPIDS_VER: 0.18
+    BUILD_IMAGE: rapidsai/rapidsai
+  - CUDA_VER: 10.1
+    LINUX_VER: centos8
+  - CUDA_VER: 10.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2
+    LINUX_VER: centos8
+  - CUDA_VER: 10.2
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -1,0 +1,40 @@
+BUILD_IMAGE:
+  - rapidsai/rapidsai-clx-dev
+  - rapidsai/rapidsai-clx-dev-nightly
+
+FROM_IMAGE:
+  - rapidsai/rapidsai-dev-nightly
+
+IMAGE_TYPE:
+  - devel
+
+RAPIDS_VER:
+  - 0.18
+
+CUDA_VER:
+  - 11.0
+  - 10.2
+  - 10.1
+
+LINUX_VER:
+  - ubuntu16.04
+  - ubuntu18.04
+  - ubuntu20.04
+  - centos7
+  - centos8
+
+PYTHON_VER:
+  - 3.7
+  - 3.8
+
+exclude:
+  - RAPIDS_VER: 0.18
+    BUILD_IMAGE: rapidsai/rapidsai-dev
+  - CUDA_VER: 10.1
+    LINUX_VER: centos8
+  - CUDA_VER: 10.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2
+    LINUX_VER: centos8
+  - CUDA_VER: 10.2
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -29,7 +29,7 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -75,4 +75,4 @@ docker images ${BUILD_IMAGE}:${BUILD_TAG}
 gpuci_logger "Starting upload..."
 GPUCI_RETRY_MAX=5
 GPUCI_RETRY_SLEEP=120
-gpuci_retry docker push ${BUILD_IMAGE}:${BUILD_TAG}
+# gpuci_retry docker push ${BUILD_IMAGE}:${BUILD_TAG}

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -42,7 +42,7 @@ def main(verbose=False):
     initialize_output_dir(OUTPUT_DIRNAME)
 
     settings = load_settings()
-    for image_name in ["rapidsai", "rapidsai-core"]:
+    for image_name in ["rapidsai", "rapidsai-core", "rapidsai-clx"]:
         templates_dir = os.path.join(TEMPLATES_DIRNAME, image_name)
         file_loader = FileSystemLoader(templates_dir)
         env = Environment(loader=file_loader, lstrip_blocks=True, trim_blocks=True)

--- a/generated-dockerfiles/rapidsai-clx_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-base.Dockerfile
@@ -3,12 +3,12 @@
 # base: RAPIDS is installed from published conda packages to the 'rapids' conda
 # environment.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=centos7
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-base.Dockerfile
@@ -1,0 +1,29 @@
+# RAPIDS Dockerfile for centos7 "base" image
+#
+# base: RAPIDS is installed from published conda packages to the 'rapids' conda
+# environment.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=centos7
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudatoolkit=${CUDA_VER}"
+    
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
@@ -5,12 +5,12 @@
 # jupyter notebooks are also provided, as well as jupyterlab and all the
 # dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=centos7
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai-dev
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
@@ -22,7 +22,7 @@ ENV CLX_DIR=${RAPIDS_DIR}/clx
 
 RUN source activate rapids && \
     gpuci_conda_retry install -y -n rapids -c pytorch \
-        "pytorch>=1.7" \
+        "pytorch=1.7.0" \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \

--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
@@ -1,0 +1,52 @@
+# RAPIDS Dockerfile for centos7 "devel" image
+#
+# RAPIDS is built from-source and installed in the base conda environment. The
+# sources and toolchains to build RAPIDS are included in this image. RAPIDS
+# jupyter notebooks are also provided, as well as jupyterlab and all the
+# dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=centos7
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai-dev
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+ENV CLX_DIR=${RAPIDS_DIR}/clx
+
+RUN source activate rapids && \
+    gpuci_conda_retry install -y -n rapids -c pytorch \
+        "pytorch>=1.7" \
+        torchvision \
+        "cudf_kafka=${RAPIDS_VER}" \
+        "custreamz=${RAPIDS_VER}" \
+        "transformers=3.5.*" \
+        seqeval \
+        python-whois \
+        faker && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget
+
+RUN cd ${RAPIDS_DIR} \
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
+
+# clx build/install
+RUN source activate rapids && \
+    cd /rapids/clx/python && \
+    python setup.py install
+WORKDIR ${RAPIDS_DIR}
+
+
+RUN conda clean -afy \
+  && chmod -R ugo+w ${CLX_DIR}
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-runtime.Dockerfile
@@ -4,12 +4,12 @@
 # conda environment. RAPIDS jupyter notebooks are also provided, as well as
 # jupyterlab and all the dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=centos7
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-runtime.Dockerfile
@@ -1,0 +1,32 @@
+# RAPIDS Dockerfile for centos7 "runtime" image
+#
+# runtime: RAPIDS is installed from published conda packages to the 'rapids'
+# conda environment. RAPIDS jupyter notebooks are also provided, as well as
+# jupyterlab and all the dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=centos7
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudf_kafka=${RAPIDS_VER}" \
+    "custreamz=${RAPIDS_VER}" \
+    seqeval \
+    python-whois \
+    "cudatoolkit=${CUDA_VER}" && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git"
+
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-base.Dockerfile
@@ -1,0 +1,29 @@
+# RAPIDS Dockerfile for centos8 "base" image
+#
+# base: RAPIDS is installed from published conda packages to the 'rapids' conda
+# environment.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=centos8
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudatoolkit=${CUDA_VER}"
+    
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-base.Dockerfile
@@ -3,12 +3,12 @@
 # base: RAPIDS is installed from published conda packages to the 'rapids' conda
 # environment.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=centos8
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
@@ -5,12 +5,12 @@
 # jupyter notebooks are also provided, as well as jupyterlab and all the
 # dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=centos8
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai-dev
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
@@ -22,7 +22,7 @@ ENV CLX_DIR=${RAPIDS_DIR}/clx
 
 RUN source activate rapids && \
     gpuci_conda_retry install -y -n rapids -c pytorch \
-        "pytorch>=1.7" \
+        "pytorch=1.7.0" \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
@@ -1,0 +1,52 @@
+# RAPIDS Dockerfile for centos8 "devel" image
+#
+# RAPIDS is built from-source and installed in the base conda environment. The
+# sources and toolchains to build RAPIDS are included in this image. RAPIDS
+# jupyter notebooks are also provided, as well as jupyterlab and all the
+# dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=centos8
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai-dev
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+ENV CLX_DIR=${RAPIDS_DIR}/clx
+
+RUN source activate rapids && \
+    gpuci_conda_retry install -y -n rapids -c pytorch \
+        "pytorch>=1.7" \
+        torchvision \
+        "cudf_kafka=${RAPIDS_VER}" \
+        "custreamz=${RAPIDS_VER}" \
+        "transformers=3.5.*" \
+        seqeval \
+        python-whois \
+        faker && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget
+
+RUN cd ${RAPIDS_DIR} \
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
+
+# clx build/install
+RUN source activate rapids && \
+    cd /rapids/clx/python && \
+    python setup.py install
+WORKDIR ${RAPIDS_DIR}
+
+
+RUN conda clean -afy \
+  && chmod -R ugo+w ${CLX_DIR}
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-runtime.Dockerfile
@@ -1,0 +1,32 @@
+# RAPIDS Dockerfile for centos8 "runtime" image
+#
+# runtime: RAPIDS is installed from published conda packages to the 'rapids'
+# conda environment. RAPIDS jupyter notebooks are also provided, as well as
+# jupyterlab and all the dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=centos8
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudf_kafka=${RAPIDS_VER}" \
+    "custreamz=${RAPIDS_VER}" \
+    seqeval \
+    python-whois \
+    "cudatoolkit=${CUDA_VER}" && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git"
+
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-runtime.Dockerfile
@@ -4,12 +4,12 @@
 # conda environment. RAPIDS jupyter notebooks are also provided, as well as
 # jupyterlab and all the dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=centos8
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-base.Dockerfile
@@ -1,0 +1,29 @@
+# RAPIDS Dockerfile for ubuntu16.04 "base" image
+#
+# base: RAPIDS is installed from published conda packages to the 'rapids' conda
+# environment.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu16.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudatoolkit=${CUDA_VER}"
+    
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-base.Dockerfile
@@ -3,12 +3,12 @@
 # base: RAPIDS is installed from published conda packages to the 'rapids' conda
 # environment.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu16.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
@@ -1,0 +1,52 @@
+# RAPIDS Dockerfile for ubuntu16.04 "devel" image
+#
+# RAPIDS is built from-source and installed in the base conda environment. The
+# sources and toolchains to build RAPIDS are included in this image. RAPIDS
+# jupyter notebooks are also provided, as well as jupyterlab and all the
+# dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu16.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai-dev
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+ENV CLX_DIR=${RAPIDS_DIR}/clx
+
+RUN source activate rapids && \
+    gpuci_conda_retry install -y -n rapids -c pytorch \
+        "pytorch>=1.7" \
+        torchvision \
+        "cudf_kafka=${RAPIDS_VER}" \
+        "custreamz=${RAPIDS_VER}" \
+        "transformers=3.5.*" \
+        seqeval \
+        python-whois \
+        faker && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget
+
+RUN cd ${RAPIDS_DIR} \
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
+
+# clx build/install
+RUN source activate rapids && \
+    cd /rapids/clx/python && \
+    python setup.py install
+WORKDIR ${RAPIDS_DIR}
+
+
+RUN conda clean -afy \
+  && chmod -R ugo+w ${CLX_DIR}
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
@@ -5,12 +5,12 @@
 # jupyter notebooks are also provided, as well as jupyterlab and all the
 # dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu16.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai-dev
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
@@ -22,7 +22,7 @@ ENV CLX_DIR=${RAPIDS_DIR}/clx
 
 RUN source activate rapids && \
     gpuci_conda_retry install -y -n rapids -c pytorch \
-        "pytorch>=1.7" \
+        "pytorch=1.7.0" \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-runtime.Dockerfile
@@ -1,0 +1,32 @@
+# RAPIDS Dockerfile for ubuntu16.04 "runtime" image
+#
+# runtime: RAPIDS is installed from published conda packages to the 'rapids'
+# conda environment. RAPIDS jupyter notebooks are also provided, as well as
+# jupyterlab and all the dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu16.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudf_kafka=${RAPIDS_VER}" \
+    "custreamz=${RAPIDS_VER}" \
+    seqeval \
+    python-whois \
+    "cudatoolkit=${CUDA_VER}" && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git"
+
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-runtime.Dockerfile
@@ -4,12 +4,12 @@
 # conda environment. RAPIDS jupyter notebooks are also provided, as well as
 # jupyterlab and all the dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu16.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-base.Dockerfile
@@ -3,12 +3,12 @@
 # base: RAPIDS is installed from published conda packages to the 'rapids' conda
 # environment.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu18.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-base.Dockerfile
@@ -1,0 +1,29 @@
+# RAPIDS Dockerfile for ubuntu18.04 "base" image
+#
+# base: RAPIDS is installed from published conda packages to the 'rapids' conda
+# environment.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu18.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudatoolkit=${CUDA_VER}"
+    
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
@@ -5,12 +5,12 @@
 # jupyter notebooks are also provided, as well as jupyterlab and all the
 # dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu18.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai-dev
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
@@ -22,7 +22,7 @@ ENV CLX_DIR=${RAPIDS_DIR}/clx
 
 RUN source activate rapids && \
     gpuci_conda_retry install -y -n rapids -c pytorch \
-        "pytorch>=1.7" \
+        "pytorch=1.7.0" \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
@@ -1,0 +1,52 @@
+# RAPIDS Dockerfile for ubuntu18.04 "devel" image
+#
+# RAPIDS is built from-source and installed in the base conda environment. The
+# sources and toolchains to build RAPIDS are included in this image. RAPIDS
+# jupyter notebooks are also provided, as well as jupyterlab and all the
+# dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu18.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai-dev
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+ENV CLX_DIR=${RAPIDS_DIR}/clx
+
+RUN source activate rapids && \
+    gpuci_conda_retry install -y -n rapids -c pytorch \
+        "pytorch>=1.7" \
+        torchvision \
+        "cudf_kafka=${RAPIDS_VER}" \
+        "custreamz=${RAPIDS_VER}" \
+        "transformers=3.5.*" \
+        seqeval \
+        python-whois \
+        faker && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget
+
+RUN cd ${RAPIDS_DIR} \
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
+
+# clx build/install
+RUN source activate rapids && \
+    cd /rapids/clx/python && \
+    python setup.py install
+WORKDIR ${RAPIDS_DIR}
+
+
+RUN conda clean -afy \
+  && chmod -R ugo+w ${CLX_DIR}
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.Dockerfile
@@ -1,0 +1,32 @@
+# RAPIDS Dockerfile for ubuntu18.04 "runtime" image
+#
+# runtime: RAPIDS is installed from published conda packages to the 'rapids'
+# conda environment. RAPIDS jupyter notebooks are also provided, as well as
+# jupyterlab and all the dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu18.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudf_kafka=${RAPIDS_VER}" \
+    "custreamz=${RAPIDS_VER}" \
+    seqeval \
+    python-whois \
+    "cudatoolkit=${CUDA_VER}" && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git"
+
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.Dockerfile
@@ -4,12 +4,12 @@
 # conda environment. RAPIDS jupyter notebooks are also provided, as well as
 # jupyterlab and all the dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu18.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-base.Dockerfile
@@ -3,12 +3,12 @@
 # base: RAPIDS is installed from published conda packages to the 'rapids' conda
 # environment.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu20.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-base.Dockerfile
@@ -1,0 +1,29 @@
+# RAPIDS Dockerfile for ubuntu20.04 "base" image
+#
+# base: RAPIDS is installed from published conda packages to the 'rapids' conda
+# environment.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu20.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudatoolkit=${CUDA_VER}"
+    
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
@@ -1,0 +1,52 @@
+# RAPIDS Dockerfile for ubuntu20.04 "devel" image
+#
+# RAPIDS is built from-source and installed in the base conda environment. The
+# sources and toolchains to build RAPIDS are included in this image. RAPIDS
+# jupyter notebooks are also provided, as well as jupyterlab and all the
+# dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu20.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai-dev
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+ENV CLX_DIR=${RAPIDS_DIR}/clx
+
+RUN source activate rapids && \
+    gpuci_conda_retry install -y -n rapids -c pytorch \
+        "pytorch>=1.7" \
+        torchvision \
+        "cudf_kafka=${RAPIDS_VER}" \
+        "custreamz=${RAPIDS_VER}" \
+        "transformers=3.5.*" \
+        seqeval \
+        python-whois \
+        faker && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget
+
+RUN cd ${RAPIDS_DIR} \
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
+
+# clx build/install
+RUN source activate rapids && \
+    cd /rapids/clx/python && \
+    python setup.py install
+WORKDIR ${RAPIDS_DIR}
+
+
+RUN conda clean -afy \
+  && chmod -R ugo+w ${CLX_DIR}
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
@@ -5,12 +5,12 @@
 # jupyter notebooks are also provided, as well as jupyterlab and all the
 # dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu20.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai-dev
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
@@ -22,7 +22,7 @@ ENV CLX_DIR=${RAPIDS_DIR}/clx
 
 RUN source activate rapids && \
     gpuci_conda_retry install -y -n rapids -c pytorch \
-        "pytorch>=1.7" \
+        "pytorch=1.7.0" \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.Dockerfile
@@ -1,0 +1,32 @@
+# RAPIDS Dockerfile for ubuntu20.04 "runtime" image
+#
+# runtime: RAPIDS is installed from published conda packages to the 'rapids'
+# conda environment. RAPIDS jupyter notebooks are also provided, as well as
+# jupyterlab and all the dependencies required to run them.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+ARG CUDA_VER=10.1
+ARG LINUX_VER=ubuntu20.04
+ARG PYTHON_VER=3.7
+ARG RAPIDS_VER=0.17
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudf_kafka=${RAPIDS_VER}" \
+    "custreamz=${RAPIDS_VER}" \
+    seqeval \
+    python-whois \
+    "cudatoolkit=${CUDA_VER}" && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git"
+
+WORKDIR ${RAPIDS_DIR}
+
+RUN conda clean -afy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.Dockerfile
@@ -4,12 +4,12 @@
 # conda environment. RAPIDS jupyter notebooks are also provided, as well as
 # jupyterlab and all the dependencies required to run them.
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 ARG CUDA_VER=10.1
 ARG LINUX_VER=ubuntu20.04
 ARG PYTHON_VER=3.7
-ARG RAPIDS_VER=0.17
+ARG RAPIDS_VER=0.18
 ARG FROM_IMAGE=rapidsai/rapidsai
 
 FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}

--- a/templates/rapidsai-clx/Base.dockerfile.j2
+++ b/templates/rapidsai-clx/Base.dockerfile.j2
@@ -1,0 +1,31 @@
+# RAPIDS Dockerfile for {{ os }} "base" image
+#
+# base: RAPIDS is installed from published conda packages to the 'rapids' conda
+# environment.
+#
+# Copyright (c) {{ now.year }}, NVIDIA CORPORATION.
+
+ARG CUDA_VER={{ DEFAULT_CUDA_VERSION }}
+ARG LINUX_VER={{ os }}
+ARG PYTHON_VER={{ DEFAULT_PYTHON_VERSION }}
+ARG RAPIDS_VER={{ DEFAULT_RAPIDS_VERSION }}
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudatoolkit=${CUDA_VER}"
+    
+WORKDIR ${RAPIDS_DIR}
+
+{# Cleanup conda #}
+RUN conda clean -afy
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+{# Set the default command to pass to the ENTRYPOINT if no command was given #}
+CMD [ "/bin/bash" ]

--- a/templates/rapidsai-clx/Devel.dockerfile.j2
+++ b/templates/rapidsai-clx/Devel.dockerfile.j2
@@ -1,0 +1,33 @@
+# RAPIDS Dockerfile for {{ os }} "devel" image
+#
+# RAPIDS is built from-source and installed in the base conda environment. The
+# sources and toolchains to build RAPIDS are included in this image. RAPIDS
+# jupyter notebooks are also provided, as well as jupyterlab and all the
+# dependencies required to run them.
+#
+# Copyright (c) {{ now.year }}, NVIDIA CORPORATION.
+
+ARG CUDA_VER={{ DEFAULT_CUDA_VERSION }}
+ARG LINUX_VER={{ os }}
+ARG PYTHON_VER={{ DEFAULT_PYTHON_VERSION }}
+ARG RAPIDS_VER={{ DEFAULT_RAPIDS_VERSION }}
+ARG FROM_IMAGE=rapidsai/rapidsai-dev
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}
+
+ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+ENV CLX_DIR=${RAPIDS_DIR}/clx
+{% include 'partials/clone_and_build_clx.dockerfile.j2' %}
+
+WORKDIR ${RAPIDS_DIR}
+
+{# Cleanup conda and set ACLs for all users #}
+{% include 'partials/cleanup-chmod.dockerfile.j2' %}
+
+COPY entrypoint.sh /opt/docker/bin/entrypoint
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+{# Set the default command to pass to the ENTRYPOINT if no command was given #}
+CMD [ "/bin/bash" ]

--- a/templates/rapidsai-clx/Runtime.dockerfile.j2
+++ b/templates/rapidsai-clx/Runtime.dockerfile.j2
@@ -1,0 +1,34 @@
+# RAPIDS Dockerfile for {{ os }} "runtime" image
+#
+# runtime: RAPIDS is installed from published conda packages to the 'rapids'
+# conda environment. RAPIDS jupyter notebooks are also provided, as well as
+# jupyterlab and all the dependencies required to run them.
+#
+# Copyright (c) {{ now.year }}, NVIDIA CORPORATION.
+
+ARG CUDA_VER={{ DEFAULT_CUDA_VERSION }}
+ARG LINUX_VER={{ os }}
+ARG PYTHON_VER={{ DEFAULT_PYTHON_VERSION }}
+ARG RAPIDS_VER={{ DEFAULT_RAPIDS_VERSION }}
+ARG FROM_IMAGE=rapidsai/rapidsai
+
+FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-runtime-${LINUX_VER}-py${PYTHON_VER}
+
+RUN gpuci_conda_retry install -y -n rapids -c pytorch \
+    "clx=${RAPIDS_VER}" \
+    "cudf_kafka=${RAPIDS_VER}" \
+    "custreamz=${RAPIDS_VER}" \
+    seqeval \
+    python-whois \
+    "cudatoolkit=${CUDA_VER}" && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git"
+
+WORKDIR ${RAPIDS_DIR}
+
+{# Cleanup conda #}
+RUN conda clean -afy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+
+{# Set the default command to pass to the ENTRYPOINT if no command was given #}
+CMD [ "/bin/bash" ]

--- a/templates/rapidsai-clx/partials/cleanup-chmod.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/cleanup-chmod.dockerfile.j2
@@ -1,0 +1,5 @@
+{# This partial file is used for cleanup and ACL changes at the end of each image #}
+
+{# Clean-up conda and update ACLs for all users #}
+RUN conda clean -afy \
+  && chmod -R ugo+w ${CLX_DIR}

--- a/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
@@ -3,7 +3,7 @@
 {# Install build prerequisites #}
 RUN source activate rapids && \
     gpuci_conda_retry install -y -n rapids -c pytorch \
-        "pytorch>=1.7" \
+        "pytorch=1.7.0" \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \

--- a/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
@@ -1,0 +1,25 @@
+{# This partial clones the CLX repo and build and installs it into the rapids conda env. #}
+
+{# Install build prerequisites #}
+RUN source activate rapids && \
+    gpuci_conda_retry install -y -n rapids -c pytorch \
+        "pytorch>=1.7" \
+        torchvision \
+        "cudf_kafka=${RAPIDS_VER}" \
+        "custreamz=${RAPIDS_VER}" \
+        "transformers=3.5.*" \
+        seqeval \
+        python-whois \
+        faker && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget
+
+{# Clone, build, install #}
+RUN cd ${RAPIDS_DIR} \
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
+
+# clx build/install
+RUN source activate rapids && \
+    cd /rapids/clx/python && \
+    python setup.py install


### PR DESCRIPTION
Add Jinja templates and generated Dockerfiles for CLX images to be published to Docker Hub and NGC.