### PR TITLE
Remove treelite from xgboost build (temporary workaround)

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -185,6 +185,8 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -209,7 +211,8 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi
+  fi && \
+  conda install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -185,6 +185,8 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -209,7 +211,8 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi
+  fi && \
+  conda install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -185,6 +185,8 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -209,7 +211,8 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi
+  fi && \
+  conda install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -185,6 +185,8 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -209,7 +211,8 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi
+  fi && \
+  conda install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -185,6 +185,8 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -209,7 +211,8 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi
+  fi && \
+  conda install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -123,6 +123,8 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh libcuspatial cuspatial tests
 
   {% elif lib.name == "xgboost" %}
+  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -147,7 +149,8 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi
+  fi && \
+  conda install -y --no-deps "${TREELITE_VER}"
 
   {% elif lib.name == "cugraph" %}
   ./build.sh --allgpuarch cugraph libcugraph


### PR DESCRIPTION
Our `devel` images are currently failing to build due to an `xgboost` error. After speaking with @hcho3, it was determined that the issue stems from `xgboost` and `treelite` depending on different versions of `dmlc`. He suggested removing `treelite` from the Python environment as a temporary workaround until he is able to implement a permanent fix. This PR includes those changes and seems to have resolved the issue during my local testing.

Here's an overview of the commands:

```sh
TREELITE_VER=$(conda list -e treelite | grep -v "#") # saves existing treelite version to env var
conda remove -y --force-remove treelite # removes treelite, but not any of its dependencies
# xgboost build happens here
conda install -y --no-deps "${TREELITE_VER}" # re-install treelite after xgboost build
```


**References:**

- `conda install` - https://docs.conda.io/projects/conda/en/latest/commands/install.html
- `conda remove` - https://docs.conda.io/projects/conda/en/latest/commands/remove.html
- `conda list` - https://docs.conda.io/projects/conda/en/latest/commands/list.html