### PR TITLE
Uncomment docker push for CI

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -75,4 +75,4 @@ docker images ${BUILD_IMAGE}:${BUILD_TAG}
 gpuci_logger "Starting upload..."
 GPUCI_RETRY_MAX=5
 GPUCI_RETRY_SLEEP=120
-# gpuci_retry docker push ${BUILD_IMAGE}:${BUILD_TAG}
+gpuci_retry docker push ${BUILD_IMAGE}:${BUILD_TAG}


### PR DESCRIPTION
It looks like the `docker push` command was commented out for testing purposes in #240 and never reverted. This PR reverts the comment.