### PR TITLE
Update HuggingFace transformers version for CLX devel images

### DIFF
--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
@@ -26,7 +26,7 @@ RUN source activate rapids && \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \
-        "transformers=3.5.*" \
+        "transformers=4.*" \
         seqeval \
         python-whois \
         faker && \

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
@@ -26,7 +26,7 @@ RUN source activate rapids && \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \
-        "transformers=3.5.*" \
+        "transformers=4.*" \
         seqeval \
         python-whois \
         faker && \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
@@ -26,7 +26,7 @@ RUN source activate rapids && \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \
-        "transformers=3.5.*" \
+        "transformers=4.*" \
         seqeval \
         python-whois \
         faker && \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
@@ -26,7 +26,7 @@ RUN source activate rapids && \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \
-        "transformers=3.5.*" \
+        "transformers=4.*" \
         seqeval \
         python-whois \
         faker && \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
@@ -26,7 +26,7 @@ RUN source activate rapids && \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \
-        "transformers=3.5.*" \
+        "transformers=4.*" \
         seqeval \
         python-whois \
         faker && \

--- a/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
@@ -7,7 +7,7 @@ RUN source activate rapids && \
         torchvision \
         "cudf_kafka=${RAPIDS_VER}" \
         "custreamz=${RAPIDS_VER}" \
-        "transformers=3.5.*" \
+        "transformers=4.*" \
         seqeval \
         python-whois \
         faker && \


### PR DESCRIPTION
CLX is updating to transformers v4 (https://github.com/rapidsai/clx/pull/322).  Doing the same for published CLX devel images.
