### PR TITLE
Fix #249: Display volume binding message only if not done by the user

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -11,5 +11,5 @@ else
    echo "To access it, visit http://localhost:8888 on your host machine."
    echo 'Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
       -p 8888:8888 -p 8787:8787 -p 8786:8786'
-   echo "Make local folders visible by bind mounting to /rapids/notebooks/host"
+   [ ! -d "/rapids/notebooks/host/" ] && echo "Make local folders visible by bind mounting to /rapids/notebooks/host"
 fi


### PR DESCRIPTION
Hi!

I have added a small check before displaying the following message, to avoid displaying it if the user has already bound a volume on the right path.

> Make local folders visible by bind mounting to /rapids/notebooks/host

Hope it helps!
Miguel