### PR TITLE
Install Jupyter kernel discovery and use nbgitpuller for examples

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -77,7 +77,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -87,9 +87,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -50,9 +50,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -77,7 +77,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -87,9 +87,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -50,9 +50,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -79,7 +79,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -89,9 +89,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -50,9 +50,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -79,7 +79,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -89,9 +89,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -50,9 +50,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -79,7 +79,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -89,9 +89,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -40,7 +40,7 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -50,9 +50,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 COPY test.sh /
 

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -7,7 +7,7 @@ RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
 {# Install jupyter lab stuff #}
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard nb_conda_kernels nbgitpuller
 
 RUN source activate rapids \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
@@ -19,9 +19,7 @@ ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 {# Install notebooks repo #}
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
-  && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/notebooks.git \
-  && cd notebooks \
-  && git submodule update --init --remote --no-single-branch --depth 1
+  && gitpuller https://github.com/rapidsai/notebooks ${BUILD_BRANCH} notebooks
 
 {# Add test file for testing notebooks from within the container #}
 COPY test.sh /


### PR DESCRIPTION
I'm working on using the RAPIDS Docker images with Jupyter Hub. 

Two small tools that would be really helpful are `nb_conda_kernels` for conda environment discovery in Jupyter and `nbgitpuller` for downloading example notebooks.

We already download the example notebooks in the RAPIDS runtime image. But `nbgitpuller` is a small utility made by the Jupyter folks to automate this, and specifically automate updating these examples. So when we launch the docker image with JupyterHub we can easily update the examples at runtime.