### PR TITLE
Add verbose flag on build.sh calls

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -146,39 +146,39 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh -v libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
   ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
+  ./build.sh -v libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh -v --allgpuarch --buildgtest libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh -v --allgpuarch cugraph libcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -146,39 +146,39 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh -v libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
   ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
+  ./build.sh -v libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh -v --allgpuarch --buildgtest libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh -v --allgpuarch cugraph libcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -146,39 +146,39 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh -v libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
   ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
+  ./build.sh -v libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh -v --allgpuarch --buildgtest libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh -v --allgpuarch cugraph libcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -146,39 +146,39 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh -v libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
   ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
+  ./build.sh -v libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh -v --allgpuarch --buildgtest libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh -v --allgpuarch cugraph libcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -146,39 +146,39 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/rapids/lib
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh -v libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuxfilter && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh
+  ./build.sh -v
 
 RUN cd ${RAPIDS_DIR}/cuspatial && \
   source activate rapids && \
   ccache -s && \
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
+  ./build.sh -v libcuspatial cuspatial tests
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh -v --allgpuarch --buildgtest libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh -v --allgpuarch cugraph libcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -110,12 +110,12 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   source activate rapids && \
   ccache -s && \
   {% if lib.name == "cudf" %}
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh -v libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
   {% elif lib.name == "cuspatial" %}
   export CUSPATIAL_HOME="$PWD" && \
   export CUDF_HOME="$PWD/../cudf" && \
-  ./build.sh libcuspatial cuspatial tests
+  ./build.sh -v libcuspatial cuspatial tests
 
   {% elif lib.name == "xgboost" %}
   TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
@@ -148,16 +148,16 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   conda install -y --no-deps "${TREELITE_VER}"
 
   {% elif lib.name == "cugraph" %}
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh -v --allgpuarch cugraph libcugraph
 
   {% elif lib.name == "cuml" %}
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh -v --allgpuarch --buildgtest libcuml cuml prims
 
   {% elif lib.name == "dask-cuda"%}
   python setup.py install
 
   {% else %}
-  ./build.sh
+  ./build.sh -v
 
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
This is to help with debugging current errors after conda gcc 9.3.0 build stack was merged, but we are still building with system level gcc 7.5.0