### PR TITLE
[Testing] Use gpuci-build-environment#159 images for testing

### DIFF
--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
   - rapidsai/rapidsai-core-nightly
 
 FROM_IMAGE:
-  - gpuci/rapidsai
+  - gpucitesting/rapidsai-pr159
 
 IMAGE_TYPE:
   - base

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
   - rapidsai/rapidsai-core-dev-nightly
 
 FROM_IMAGE:
-  - gpuci/rapidsai
+  - gpucitesting/rapidsai-pr159
 
 IMAGE_TYPE:
   - devel


### PR DESCRIPTION
Use the images generated with rapidsai/gpuci-build-environment#159 for testing to see if the gcc7 issues are resolved

**NOTE:** PR created in repo for use with existing test/build scripts; no need to merge PR. Created for tracking the testing process