### PR TITLE
[REVIEW] FIX Reproduce symlinks to ccache before source builds

### DIFF
--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
@@ -34,6 +34,10 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
 

--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
@@ -35,9 +35,9 @@ RUN source activate rapids && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
@@ -46,6 +46,10 @@ RUN cd ${RAPIDS_DIR} \
 RUN source activate rapids && \
     cd /rapids/clx/python && \
     python setup.py install
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
@@ -34,6 +34,10 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
 

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
@@ -35,9 +35,9 @@ RUN source activate rapids && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
@@ -46,6 +46,10 @@ RUN cd ${RAPIDS_DIR} \
 RUN source activate rapids && \
     cd /rapids/clx/python && \
     python setup.py install
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
@@ -34,6 +34,10 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
@@ -35,9 +35,9 @@ RUN source activate rapids && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
@@ -46,6 +46,10 @@ RUN cd ${RAPIDS_DIR} \
 RUN source activate rapids && \
     cd /rapids/clx/python && \
     python setup.py install
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
@@ -34,6 +34,10 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
@@ -35,9 +35,9 @@ RUN source activate rapids && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
@@ -46,6 +46,10 @@ RUN cd ${RAPIDS_DIR} \
 RUN source activate rapids && \
     cd /rapids/clx/python && \
     python setup.py install
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
@@ -34,6 +34,10 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
@@ -35,9 +35,9 @@ RUN source activate rapids && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git
@@ -46,6 +46,10 @@ RUN cd ${RAPIDS_DIR} \
 RUN source activate rapids && \
     cd /rapids/clx/python && \
     python setup.py install
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -218,6 +218,9 @@ RUN cd ${RAPIDS_DIR}/dask-cuda && \
   python setup.py install
 
 
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_PREBUILD}
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -218,6 +218,9 @@ RUN cd ${RAPIDS_DIR}/dask-cuda && \
   python setup.py install
 
 
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_PREBUILD}
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -218,6 +218,9 @@ RUN cd ${RAPIDS_DIR}/dask-cuda && \
   python setup.py install
 
 
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 
 RUN ccache -s \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -218,6 +218,9 @@ RUN cd ${RAPIDS_DIR}/dask-cuda && \
   python setup.py install
 
 
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 
 RUN ccache -s \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -218,6 +218,9 @@ RUN cd ${RAPIDS_DIR}/dask-cuda && \
   python setup.py install
 
 
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 
 RUN ccache -s \

--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -37,9 +37,9 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
@@ -55,6 +55,10 @@ RUN source activate rapids \
     && ccache -s \
     && cd ${BLAZING_DIR}/blazingsql \
     && ./build.sh
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
 ENV LD_LIBRARY_PATH_ORIG=

--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -37,6 +37,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -37,9 +37,9 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
@@ -55,6 +55,10 @@ RUN source activate rapids \
     && ccache -s \
     && cd ${BLAZING_DIR}/blazingsql \
     && ./build.sh
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
 ENV LD_LIBRARY_PATH_ORIG=

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -37,6 +37,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
@@ -37,9 +37,9 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
@@ -54,6 +54,10 @@ RUN source activate rapids \
     && ccache -s \
     && cd ${BLAZING_DIR}/blazingsql \
     && ./build.sh
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
 ENV LD_LIBRARY_PATH_ORIG=

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
@@ -37,6 +37,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -37,9 +37,9 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
@@ -54,6 +54,10 @@ RUN source activate rapids \
     && ccache -s \
     && cd ${BLAZING_DIR}/blazingsql \
     && ./build.sh
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
 ENV LD_LIBRARY_PATH_ORIG=

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -37,6 +37,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -37,9 +37,9 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
@@ -54,6 +54,10 @@ RUN source activate rapids \
     && ccache -s \
     && cd ${BLAZING_DIR}/blazingsql \
     && ./build.sh
+
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
 ENV LD_LIBRARY_PATH_ORIG=

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -37,6 +37,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git

--- a/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
@@ -15,6 +15,10 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 {# Clone, build, install #}
 RUN cd ${RAPIDS_DIR} \
     && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/clx.git

--- a/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
@@ -16,9 +16,10 @@ RUN source activate rapids && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+{# Link to ccache compiler symlinks #}
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 {# Clone, build, install #}
 RUN cd ${RAPIDS_DIR} \
@@ -28,3 +29,8 @@ RUN cd ${RAPIDS_DIR} \
 RUN source activate rapids && \
     cd /rapids/clx/python && \
     python setup.py install
+
+{# Link to default compiler executables #}
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -162,6 +162,10 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   {% endif %}
 {% endfor %}
 
+{# Link to default compiler executables #}
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 {% if "centos" in os %}
 {# Change LD_LIBRARY_PATH to exclude /usr/local/cuda/* since

--- a/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
@@ -12,6 +12,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
+RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
+    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
+    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+
 {# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \

--- a/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
@@ -12,9 +12,10 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
 
 ENV CUDF_HOME=/rapids/cudf
 
-RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
+{# Link to ccache compiler symlinks #}
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+ENV NVCC="/usr/local/bin/nvcc"
 
 {# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
@@ -43,6 +44,11 @@ RUN source activate rapids \
     && ccache -s \
     && cd ${BLAZING_DIR}/blazingsql \
     && ./build.sh
+
+{# Link to default compiler executables #}
+ENV CC="/usr/bin/gcc"
+ENV CXX="/usr/bin/g++"
+ENV NVCC="/usr/local/cuda/bin/nvcc"
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
 ENV LD_LIBRARY_PATH_ORIG=


### PR DESCRIPTION
Fixes the problems with builds losing access to compilers. It seems like installing new packages activates the `deactivate.sh` script from `rapids-scout-local` which removes symlinks to ccache which source builds rely on for finding compilers.

Tested locally with a full docker build, succeeded. Changes are OS/CUDA/Python agnostic so it should work across all of our supported software.