### PR TITLE
FIX Update `LD_LIBRARY_PATH` to remove errors in Ubuntu/CentOS & add logic for PR builds

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -15,7 +15,7 @@ env
 
 # Login to docker
 gpuci_logger "Logging into Docker..."
-echo $DH_TOKEN | docker login --username $DH_USER --password-stdin
+echo $DH_TOKEN | docker login --username $DH_USER --password-stdin &> /dev/null
 
 # Select dockerfile based on matrix var
 DOCKERFILE="${DOCKER_PREFIX}_${LINUX_VER}-${IMAGE_TYPE}.Dockerfile"

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -19,7 +19,6 @@ echo $DH_TOKEN | docker login --username $DH_USER --password-stdin &> /dev/null
 
 # Select dockerfile based on matrix var
 DOCKERFILE="${DOCKER_PREFIX}_${LINUX_VER}-${IMAGE_TYPE}.Dockerfile"
-
 gpuci_logger "Using Dockerfile: generated-dockerfiles/${DOCKERFILE}"
 
 # Debug output selected dockerfile
@@ -30,6 +29,21 @@ gpuci_logger ">>>> END Dockerfile <<<<"
 # Get build info ready
 gpuci_logger "Preparing build config..."
 BUILD_TAG="cuda${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
+# Check if PR build and modify BUILD_IMAGE and BUILD_TAG
+if [ ! -z "$PR_ID" ] ; then
+  echo "PR_ID is set to '$PR_ID', updating BUILD_IMAGE..."
+  BUILD_REPO=`echo $BUILD_IMAGE | tr '/' ' ' | awk '{ print $2 }'`
+  BUILD_IMAGE="rapidsaitesting/${BUILD_REPO}-pr${PR_ID}"
+  # Check if FROM_IMAGE to see if it is a root build
+  if [[ "$FROM_IMAGE" == "gpuci/rapidsai" ]] ; then
+    echo ">> No need to update FROM_IMAGE, using external image..."
+  else
+    echo ">> Need to update FROM_IMAGE to use PR's version for testing..."
+    FROM_REPO=`echo $FROM_IMAGE | tr '/' ' ' | awk '{ print $2 }'`
+    FROM_IMAGE="rapidsaitesting/${FROM_REPO}-pr${PR_ID}"
+  fi
+fi
+# Setup initial BUILD_ARGS
 BUILD_ARGS="--squash \
   --build-arg FROM_IMAGE=${FROM_IMAGE} \
   --build-arg CUDA_VER=${CUDA_VER} \

--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.Dockerfile
@@ -45,8 +45,9 @@ RUN source activate rapids && \
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
-  && chmod -R ugo+w ${CLX_DIR}
+RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
+  && conda clean -tipy \
+  && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.Dockerfile
@@ -45,8 +45,9 @@ RUN source activate rapids && \
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
-  && chmod -R ugo+w ${CLX_DIR}
+RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
+  && conda clean -tipy \
+  && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu16.04-devel.Dockerfile
@@ -45,8 +45,9 @@ RUN source activate rapids && \
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
-  && chmod -R ugo+w ${CLX_DIR}
+RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
+  && conda clean -tipy \
+  && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.Dockerfile
@@ -45,8 +45,9 @@ RUN source activate rapids && \
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
-  && chmod -R ugo+w ${CLX_DIR}
+RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
+  && conda clean -tipy \
+  && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.Dockerfile
@@ -45,8 +45,9 @@ RUN source activate rapids && \
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
-  && chmod -R ugo+w ${CLX_DIR}
+RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
+  && conda clean -tipy \
+  && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -35,7 +35,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 WORKDIR ${RAPIDS_DIR}
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -226,7 +226,8 @@ RUN ccache -s \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
   conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi && \
-  conda install -y --no-deps "${TREELITE_VER}"
+  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -63,7 +63,8 @@ EXPOSE 8786
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -35,7 +35,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 WORKDIR ${RAPIDS_DIR}
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -226,7 +226,8 @@ RUN ccache -s \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
   conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi && \
-  conda install -y --no-deps "${TREELITE_VER}"
+  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -63,7 +63,8 @@ EXPOSE 8786
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -35,7 +35,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 WORKDIR ${RAPIDS_DIR}
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -17,7 +17,6 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 
 ENV RAPIDS_DIR=/rapids
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -225,7 +225,8 @@ RUN ccache -s \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
   conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi && \
-  conda install -y --no-deps "${TREELITE_VER}"
+  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -63,7 +63,8 @@ EXPOSE 8786
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -19,7 +19,6 @@ ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -35,7 +35,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 WORKDIR ${RAPIDS_DIR}
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -17,7 +17,6 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 
 ENV RAPIDS_DIR=/rapids
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -225,7 +225,8 @@ RUN ccache -s \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
   conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi && \
-  conda install -y --no-deps "${TREELITE_VER}"
+  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -63,7 +63,8 @@ EXPOSE 8786
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -19,7 +19,6 @@ ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -35,7 +35,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 WORKDIR ${RAPIDS_DIR}
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -17,7 +17,6 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 
 ENV RAPIDS_DIR=/rapids
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -225,7 +225,8 @@ RUN ccache -s \
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
   conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi && \
-  conda install -y --no-deps "${TREELITE_VER}"
+  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -63,7 +63,8 @@ EXPOSE 8786
 COPY packages.sh /opt/docker/bin/
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -19,7 +19,6 @@ ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/

--- a/generated-dockerfiles/rapidsai_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-base.Dockerfile
@@ -22,7 +22,8 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql\
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-base.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -57,7 +57,8 @@ ENV LD_LIBRARY_PATH_ORIG=
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -58,7 +58,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
@@ -29,7 +29,8 @@ COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-base.Dockerfile
@@ -22,7 +22,8 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql\
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-base.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -57,7 +57,8 @@ ENV LD_LIBRARY_PATH_ORIG=
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -58,7 +58,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-runtime.Dockerfile
@@ -29,7 +29,8 @@ COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-runtime.Dockerfile
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-base.Dockerfile
@@ -22,7 +22,8 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql\
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-base.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
@@ -57,7 +57,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-devel.Dockerfile
@@ -56,7 +56,8 @@ ENV LD_LIBRARY_PATH_ORIG=
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-runtime.Dockerfile
@@ -29,7 +29,8 @@ COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu16.04-runtime.Dockerfile
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-base.Dockerfile
@@ -22,7 +22,8 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql\
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-base.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -57,7 +57,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -56,7 +56,8 @@ ENV LD_LIBRARY_PATH_ORIG=
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
@@ -29,7 +29,8 @@ COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-base.Dockerfile
@@ -22,7 +22,8 @@ RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql\
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-base.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -57,7 +57,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -56,7 +56,8 @@ ENV LD_LIBRARY_PATH_ORIG=
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.Dockerfile
@@ -29,7 +29,8 @@ COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.Dockerfile
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 

--- a/templates/rapidsai-clx/partials/cleanup-chmod.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/cleanup-chmod.dockerfile.j2
@@ -1,5 +1,6 @@
 {# This partial file is used for cleanup and ACL changes at the end of each image #}
 
 {# Clean-up conda and update ACLs for all users #}
-RUN conda clean -afy \
-  && chmod -R ugo+w ${CLX_DIR}
+RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
+  && conda clean -tipy \
+  && chmod -R ugo+w /opt/conda ${CLX_DIR}

--- a/templates/rapidsai-core/Base.dockerfile.j2
+++ b/templates/rapidsai-core/Base.dockerfile.j2
@@ -18,9 +18,6 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 
 ENV RAPIDS_DIR=/rapids
-{% if "ubuntu" in os %}
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
-{% endif %}
 
 {# Copy files needed by RAPIDS and 3rd parties for builds, test, and runtime. #}
 RUN mkdir -p ${RAPIDS_DIR}/utils {{ "${GCC7_DIR}/lib64" if "centos" in os }}

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -115,7 +115,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh libcuspatial cuspatial tests
 
   {% elif lib.name == "xgboost" %}
-  TREELITE_VER=$(conda list -e treelite | grep -v "#") && \
+  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
   conda remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -142,7 +142,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
   fi && \
-  conda install -y --no-deps "${TREELITE_VER}"
+  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
 
   {% elif lib.name == "cugraph" %}
   ./build.sh --allgpuarch cugraph libcugraph

--- a/templates/rapidsai-core/Runtime.dockerfile.j2
+++ b/templates/rapidsai-core/Runtime.dockerfile.j2
@@ -20,9 +20,6 @@ ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
 ENV RAPIDS_DIR=/rapids
-{% if "ubuntu" in os %}
-ENV LD_LIBRARY_PATH=/opt/conda/envs/rapids/lib:${LD_LIBRARY_PATH}
-{% endif %}
 
 {# Copy files needed by RAPIDS and 3rd parties for builds, test, and runtime. #}
 RUN mkdir -p ${RAPIDS_DIR}/utils {{ "${GCC7_DIR}/lib64" if "centos" in os }}

--- a/templates/rapidsai-core/partials/cleanup-chmod.dockerfile.j2
+++ b/templates/rapidsai-core/partials/cleanup-chmod.dockerfile.j2
@@ -1,5 +1,6 @@
 {# This partial file is used for cleanup and ACL changes at the end of each image #}
 
 {# Clean-up conda and update ACLs for all users #}
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR}

--- a/templates/rapidsai/partials/cleanup-chmod.dockerfile.j2
+++ b/templates/rapidsai/partials/cleanup-chmod.dockerfile.j2
@@ -2,5 +2,5 @@
 
 {# Clean-up conda and update ACLs for all users #}
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
-  && conda clean -tipsy \
+  && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}

--- a/templates/rapidsai/partials/cleanup-chmod.dockerfile.j2
+++ b/templates/rapidsai/partials/cleanup-chmod.dockerfile.j2
@@ -1,5 +1,6 @@
 {# This partial file is used for cleanup and ACL changes at the end of each image #}
 
 {# Clean-up conda and update ACLs for all users #}
-RUN conda clean -afy \
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
+  && conda clean -tipsy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}


### PR DESCRIPTION
This addresses the following:

- Fixes `LD_LIBRARY_PATH` that caused errors in both Ubuntu & CentOS
  - Which prevented use of `yum` on CentOS and caused error messages while using `bash` on Ubuntu 20.04 while troubleshooting #254 
- Updates `conda clean` commands to match those in rapidsai/gpuci-build-environment#162
- Adds logic for PR testing, remapping uploaded builds
  - Publishes images to the `rapidsaitesting` repo similar to `gpucitesting` repo used for `gpuci-build-environment`
  - Also allows for easier testing of this PR while not impacting the current nightlies

_Branch pushed to repo for testing as scripts do not support testing from forks currently_