### PR TITLE
Add 0.19 axis exclusions

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -32,6 +32,8 @@ PYTHON_VER:
 exclude:
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai
+  - RAPIDS_VER: 0.19
+    BUILD_IMAGE: rapidsai/rapidsai
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -32,6 +32,8 @@ PYTHON_VER:
 exclude:
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-clx
+  - RAPIDS_VER: 0.19
+    BUILD_IMAGE: rapidsai/rapidsai-clx
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -10,7 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - 0.18
-  - 0.19 
+  - 0.19
 
 CUDA_VER:
   - 11.0
@@ -30,6 +30,8 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: 0.18
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
+  - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev
   - CUDA_VER: 10.1
     LINUX_VER: centos8

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -32,6 +32,8 @@ PYTHON_VER:
 exclude:
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-core
+  - RAPIDS_VER: 0.19
+    BUILD_IMAGE: rapidsai/rapidsai-core
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -31,6 +31,8 @@ PYTHON_VER:
 exclude:
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-core-dev
+  - RAPIDS_VER: 0.19
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -31,6 +31,8 @@ PYTHON_VER:
 exclude:
   - RAPIDS_VER: 0.18
     BUILD_IMAGE: rapidsai/rapidsai-dev
+  - RAPIDS_VER: 0.19
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - CUDA_VER: 10.1
     LINUX_VER: centos8
   - CUDA_VER: 10.1


### PR DESCRIPTION
This PR adds `0.19` stable images to the exclusions.