### PR TITLE
FIX Update cudf `build.sh` to use `--allgpuarch` & remove 0.18 from gpuCI axis

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - 0.18
   - 0.19
 
 CUDA_VER:
@@ -30,8 +29,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai
   - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - 0.18
   - 0.19
 
 CUDA_VER:
@@ -30,8 +29,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai-clx
   - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai-clx
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -9,7 +9,6 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - 0.18
   - 0.19
 
 CUDA_VER:
@@ -29,8 +28,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
   - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - 0.18
   - 0.19
 
 CUDA_VER:
@@ -30,8 +29,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai-core
   - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai-core
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -9,7 +9,6 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - 0.18
   - 0.19
 
 CUDA_VER:
@@ -29,8 +28,6 @@ PYTHON_VER:
   - 3.7
 
 exclude:
-  - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - CUDA_VER: 10.1

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -9,7 +9,6 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - 0.18
   - 0.19
 
 CUDA_VER:
@@ -29,8 +28,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.18
-    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: 0.19
     BUILD_IMAGE: rapidsai/rapidsai-dev
   - CUDA_VER: 10.1

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -148,7 +148,7 @@ RUN cd ${RAPIDS_DIR}/rmm && \
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -148,7 +148,7 @@ RUN cd ${RAPIDS_DIR}/rmm && \
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -148,7 +148,7 @@ RUN cd ${RAPIDS_DIR}/rmm && \
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -148,7 +148,7 @@ RUN cd ${RAPIDS_DIR}/rmm && \
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -148,7 +148,7 @@ RUN cd ${RAPIDS_DIR}/rmm && \
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
   ccache -s && \
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -107,7 +107,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   source activate rapids && \
   ccache -s && \
   {% if lib.name == "cudf" %}
-  ./build.sh libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
   {% elif lib.name == "cuspatial" %}
   export CUSPATIAL_HOME="$PWD" && \


### PR DESCRIPTION
Recent changes to `branch-0.19` for `cudf` have made `--allgpuarch` a required flag for `build.sh`. We build our docker images on CPU-only machines so the updated auto-detection for GPUs to build for the local architecture does not work. It will be patched in rapidsai/cudf#7107.

Until then this PR serves as a workaround so we can build and publish 0.19 nightly images.