### PR TITLE
Update DockerHub READMEs for 0.18 release

### DIFF
--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0), `blazingsql` [v0.17](https://github.com/BlazingDB/blazingsql/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0), `blazingsql` [v0.18](https://github.com/BlazingDB/blazingsql/tree/v0.18.0)
 
 
 ### Image Types
@@ -34,7 +34,7 @@ For `devel` images that contain: the full RAPIDS source tree, pre-built with all
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+0.18-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -64,16 +64,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -107,7 +107,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -130,12 +130,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -144,7 +144,7 @@ Notebooks can be found in the following directories within the 0.17 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -154,14 +154,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -17,10 +17,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-clx-dev-nightly` repo contains nightly docker builds of the latest WIP changes merged into GitHub repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai-clx-dev](https://hub.docker.com/r/rapidsai/rapidsai-clx-dev) containers.
 
-### RAPIDS NIGHTLY v0.18a
+### RAPIDS NIGHTLY v0.19a
 
-Versions of libraries included in the `0.18` images:
-- `cuDF` [v0.18.0a](https://github.com/rapidsai/cudf), `cuML` [v0.18.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.18.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.18.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.18.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.18.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.18.0a](https://github.com/rapidsai/cuxfilter), `clx` [v0.18](https://github.com/rapidsai/clx)
+Versions of libraries included in the `0.19` images:
+- `cuDF` [v0.19.0a](https://github.com/rapidsai/cudf), `cuML` [v0.19.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.19.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.19.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.19.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.19.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.19.0a](https://github.com/rapidsai/cuxfilter), `clx` [v0.19](https://github.com/rapidsai/clx)
 - `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
@@ -44,7 +44,7 @@ This repo (rapidsai/rapidsai-clx-dev-nightly), contains the following:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.18-cuda10.1-devel-ubuntu18.04-py3.7
+0.19-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -68,16 +68,16 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -111,7 +111,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -134,12 +134,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.18 container :
+Notebooks can be found in the following directories within the 0.19 container :
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -148,7 +148,7 @@ Notebooks can be found in the following directories within the 0.18 container :
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.19/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -158,14 +158,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0), `clx` [v0.17](https://github.com/rapidsai/clx/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0), `clx` [v0.18](https://github.com/rapidsai/clx/tree/v0.18.0)
 
 
 ### Image Types
@@ -38,7 +38,7 @@ This repo (rapidsai/rapidsai-clx-dev), contains the following:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-devel-ubuntu18.04-py3.7
+0.18-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -62,16 +62,16 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -105,7 +105,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -128,12 +128,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container :
+Notebooks can be found in the following directories within the 0.18 container :
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -142,7 +142,7 @@ Notebooks can be found in the following directories within the 0.17 container :
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -152,14 +152,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -17,10 +17,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-clx-nightly` repo contains nightly docker builds of the latest WIP changes merged into GitHub repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai-clx](https://hub.docker.com/r/rapidsai/rapidsai-clx) containers.
 
-### RAPIDS NIGHTLY v0.18a
+### RAPIDS NIGHTLY v0.19a
 
-Versions of libraries included in the `0.18` images:
-- `cuDF` [v0.18.0a](https://github.com/rapidsai/cudf), `cuML` [v0.18.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.18.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.18.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.18.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.18.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.18.0a](https://github.com/rapidsai/cuxfilter), `clx` [v0.18](https://github.com/rapidsai/clx)
+Versions of libraries included in the `0.19` images:
+- `cuDF` [v0.19.0a](https://github.com/rapidsai/cudf), `cuML` [v0.19.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.19.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.19.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.19.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.19.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.19.0a](https://github.com/rapidsai/cuxfilter), `clx` [v0.19](https://github.com/rapidsai/clx)
 - `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
@@ -44,7 +44,7 @@ The [rapidsai/rapidsai-clx-dev-nightly](https://hub.docker.com/r/rapidsai/rapids
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+0.19-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -74,16 +74,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -117,7 +117,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -140,12 +140,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.19 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -154,7 +154,7 @@ Notebooks can be found in the following directories within the 0.18 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.19/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -164,14 +164,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0), `clx` [v0.17](https://github.com/rapidsai/clx/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0), `clx` [v0.18](https://github.com/rapidsai/clx/tree/v0.18.0)
 
 
 ### Image Types
@@ -38,7 +38,7 @@ The [rapidsai/rapidsai-clx-dev](https://hub.docker.com/r/rapidsai/rapidsai-clx-d
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+0.18-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -68,16 +68,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -111,7 +111,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -134,12 +134,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -148,7 +148,7 @@ Notebooks can be found in the following directories within the 0.17 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -158,14 +158,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-clx:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-clx:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -17,10 +17,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-core-dev-nightly` repo contains nightly docker builds of the latest WIP changes merged into GitHub repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai-core-dev](https://hub.docker.com/r/rapidsai/rapidsai-core-dev) containers.
 
-### RAPIDS NIGHTLY v0.18a
+### RAPIDS NIGHTLY v0.19a
 
-Versions of libraries included in the `0.18` images:
-- `cuDF` [v0.18.0a](https://github.com/rapidsai/cudf), `cuML` [v0.18.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.18.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.18.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.18.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.18.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.18.0a](https://github.com/rapidsai/cuxfilter)
+Versions of libraries included in the `0.19` images:
+- `cuDF` [v0.19.0a](https://github.com/rapidsai/cudf), `cuML` [v0.19.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.19.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.19.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.19.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.19.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.19.0a](https://github.com/rapidsai/cuxfilter)
 - `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
@@ -44,7 +44,7 @@ This repo (rapidsai/rapidsai-core-dev-nightly), contains the following:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.18-cuda10.1-devel-ubuntu18.04-py3.7
+0.19-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -68,16 +68,16 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -111,7 +111,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -134,12 +134,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.18 container :
+Notebooks can be found in the following directories within the 0.19 container :
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -148,7 +148,7 @@ Notebooks can be found in the following directories within the 0.18 container :
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.19/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -158,14 +158,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0)
 
 
 ### Image Types
@@ -38,7 +38,7 @@ This repo (rapidsai/rapidsai-core-dev), contains the following:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-devel-ubuntu18.04-py3.7
+0.18-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -62,16 +62,16 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -105,7 +105,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -128,12 +128,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container :
+Notebooks can be found in the following directories within the 0.18 container :
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -142,7 +142,7 @@ Notebooks can be found in the following directories within the 0.17 container :
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -152,14 +152,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -17,10 +17,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-core-nightly` repo contains nightly docker builds of the latest WIP changes merged into GitHub repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai-core](https://hub.docker.com/r/rapidsai/rapidsai-core) containers.
 
-### RAPIDS NIGHTLY v0.18a
+### RAPIDS NIGHTLY v0.19a
 
-Versions of libraries included in the `0.18` images:
-- `cuDF` [v0.18.0a](https://github.com/rapidsai/cudf), `cuML` [v0.18.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.18.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.18.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.18.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.18.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.18.0a](https://github.com/rapidsai/cuxfilter)
+Versions of libraries included in the `0.19` images:
+- `cuDF` [v0.19.0a](https://github.com/rapidsai/cudf), `cuML` [v0.19.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.19.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.19.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.19.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.19.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.19.0a](https://github.com/rapidsai/cuxfilter)
 - `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
@@ -44,7 +44,7 @@ The [rapidsai/rapidsai-core-dev-nightly](https://hub.docker.com/r/rapidsai/rapid
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+0.19-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -74,16 +74,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -117,7 +117,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -140,12 +140,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.19 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -154,7 +154,7 @@ Notebooks can be found in the following directories within the 0.18 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.19/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -164,14 +164,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0)
 
 
 ### Image Types
@@ -38,7 +38,7 @@ The [rapidsai/rapidsai-core-dev](https://hub.docker.com/r/rapidsai/rapidsai-core
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+0.18-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -68,16 +68,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -111,7 +111,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -134,12 +134,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -148,7 +148,7 @@ Notebooks can be found in the following directories within the 0.17 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -158,14 +158,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-core:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-core:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -17,11 +17,11 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-dev-nightly` repo contains nightly docker builds of the latest WIP changes merged into GitHub repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev) containers.
 
-### RAPIDS NIGHTLY v0.18a
+### RAPIDS NIGHTLY v0.19a
 
-Versions of libraries included in the `0.18` images:
-- `cuDF` [v0.18.0a](https://github.com/rapidsai/cudf), `cuML` [v0.18.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.18.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.18.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.18.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.18.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.18.0a](https://github.com/rapidsai/cuxfilter)
-- `blazingsql` [v0.18](https://github.com/BlazingDB/blazingsql), `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
+Versions of libraries included in the `0.19` images:
+- `cuDF` [v0.19.0a](https://github.com/rapidsai/cudf), `cuML` [v0.19.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.19.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.19.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.19.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.19.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.19.0a](https://github.com/rapidsai/cuxfilter)
+- `blazingsql` [v0.19](https://github.com/BlazingDB/blazingsql), `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
 
@@ -44,7 +44,7 @@ This repo (rapidsai/rapidsai-dev-nightly), contains the following:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.18-cuda10.1-devel-ubuntu18.04-py3.7
+0.19-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -68,16 +68,16 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -111,7 +111,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -134,12 +134,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.18 container :
+Notebooks can be found in the following directories within the 0.19 container :
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -148,7 +148,7 @@ Notebooks can be found in the following directories within the 0.18 container :
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.19/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -158,14 +158,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev-nightly:0.18-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-dev-nightly:0.19-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0), `blazingsql` [v0.17](https://github.com/BlazingDB/blazingsql/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0), `blazingsql` [v0.18](https://github.com/BlazingDB/blazingsql/tree/v0.18.0)
 
 
 ### Image Types
@@ -38,7 +38,7 @@ This repo (rapidsai/rapidsai-dev), contains the following:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-devel-ubuntu18.04-py3.7
+0.18-cuda10.1-devel-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -62,16 +62,16 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+         rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -105,7 +105,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -128,12 +128,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container :
+Notebooks can be found in the following directories within the 0.18 container :
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -142,7 +142,7 @@ Notebooks can be found in the following directories within the 0.17 container :
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -152,14 +152,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev:0.17-cuda10.1-devel-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-dev:0.18-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -17,11 +17,11 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 The `rapidsai/rapidsai-nightly` repo contains nightly docker builds of the latest WIP changes merged into GitHub repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) containers.
 
-### RAPIDS NIGHTLY v0.18a
+### RAPIDS NIGHTLY v0.19a
 
-Versions of libraries included in the `0.18` images:
-- `cuDF` [v0.18.0a](https://github.com/rapidsai/cudf), `cuML` [v0.18.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.18.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.18.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.18.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.18.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.18.0a](https://github.com/rapidsai/cuxfilter)
-- `blazingsql` [v0.18](https://github.com/BlazingDB/blazingsql), `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
+Versions of libraries included in the `0.19` images:
+- `cuDF` [v0.19.0a](https://github.com/rapidsai/cudf), `cuML` [v0.19.0a](https://github.com/rapidsai/cuml), `cuGraph` [v0.19.0a](https://github.com/rapidsai/cugraph), `RMM` [v0.19.0a](https://github.com/rapidsai/RMM), `cuSpatial` [v0.19.0a](https://github.com/rapidsai/cuspatial), `cuSignal` [v0.19.0a](https://github.com/rapidsai/cusignal), `cuxfilter` [v0.19.0a](https://github.com/rapidsai/cuxfilter)
+- `blazingsql` [v0.19](https://github.com/BlazingDB/blazingsql), `xgboost` [branch](https://github.com/rapidsai/xgboost), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
 
 ### Image Types
 
@@ -44,7 +44,7 @@ The [rapidsai/rapidsai-dev-nightly](https://hub.docker.com/r/rapidsai/rapidsai-d
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+0.19-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -74,16 +74,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -117,7 +117,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -140,12 +140,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.19 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -154,7 +154,7 @@ Notebooks can be found in the following directories within the 0.18 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.19/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -164,14 +164,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-nightly:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai-nightly:0.19-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -11,10 +11,10 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
 
-### Current Version - RAPIDS v0.17
+### Current Version - RAPIDS v0.18
 
-Versions of libraries included in the `0.17` images:
-- `cuDF` [v0.17](https://github.com/rapidsai/cudf/tree/v0.17.0), `cuML` [v0.17](https://github.com/rapidsai/cuml/tree/v0.17.0), `cuGraph` [v0.17](https://github.com/rapidsai/cugraph/tree/v0.17.0), `RMM` [v0.17](https://github.com/rapidsai/RMM/tree/v0.17.0), `cuSpatial` [v0.17](https://github.com/rapidsai/cuspatial/tree/v0.17.0), `cuSignal` [v0.17](https://github.com/rapidsai/cusignal/tree/v0.17.0), `cuxfilter` [v0.17](https://github.com/rapidsai/cuxfilter/tree/v0.17.0), `blazingsql` [v0.17](https://github.com/BlazingDB/blazingsql/tree/v0.17.0)
+Versions of libraries included in the `0.18` images:
+- `cuDF` [v0.18](https://github.com/rapidsai/cudf/tree/v0.18.0), `cuML` [v0.18](https://github.com/rapidsai/cuml/tree/v0.18.0), `cuGraph` [v0.18](https://github.com/rapidsai/cugraph/tree/v0.18.0), `RMM` [v0.18](https://github.com/rapidsai/RMM/tree/v0.18.0), `cuSpatial` [v0.18](https://github.com/rapidsai/cuspatial/tree/v0.18.0), `cuSignal` [v0.18](https://github.com/rapidsai/cusignal/tree/v0.18.0), `cuxfilter` [v0.18](https://github.com/rapidsai/cuxfilter/tree/v0.18.0), `blazingsql` [v0.18](https://github.com/BlazingDB/blazingsql/tree/v0.18.0)
 
 
 ### Image Types
@@ -38,7 +38,7 @@ The [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags)
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+0.18-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -68,16 +68,16 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+$ docker pull rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+         rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Container Ports
@@ -111,7 +111,7 @@ $ docker run \
     -p 8888:8888 \
     -p 8787:8787 \
     -p 8786:8786 \
-    rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Bind Mounts
@@ -134,12 +134,12 @@ $ docker run \
     -it \
     --gpus all \
     -v $(pwd)/environment.yml:/opt/rapids/environment.yml \
-    rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+    rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.17 container (not applicable for `base` images):
+Notebooks can be found in the following directories within the 0.18 container (not applicable for `base` images):
 
 * `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
@@ -148,7 +148,7 @@ Notebooks can be found in the following directories within the 0.17 container (n
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.17/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.18/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 
@@ -158,14 +158,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04-py3.7
+                  rapidsai/rapidsai:0.18-cuda10.1-runtime-ubuntu18.04-py3.7
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 


### PR DESCRIPTION
This PR updates the DockerHub READMEs for the `0.18` release.