### PR TITLE
Fix DockerHub README Scripts

### DIFF
--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -15,9 +15,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Generate new Dockerfiles & READMEs
         run: |
+          RAPIDS_NIGHTLY_VERSION=$(grep DEFAULT_RAPIDS_VERSION settings.yaml | sed 's/.*\.//' | sed 's/[" ]//g')
+          [ "${BASE_BRANCH_NAME}" = "main" ] && let RAPIDS_NIGHTLY_VERSION++
+
           pip install -r requirements.txt
           ./generate_dockerfiles.py
-          ./dockerhub-readme/generate_readmes.py
+          ./dockerhub-readme/generate_readmes.py -n ${RAPIDS_NIGHTLY_VERSION}
+        env:
+          BASE_BRANCH_NAME: ${{ github.base_ref }}
       - name: Check diffs
         run: |
           git diff

--- a/dockerhub-readme/generate_readmes.py
+++ b/dockerhub-readme/generate_readmes.py
@@ -6,6 +6,7 @@ Python script to generate DockerHub READMEs
 import os
 from jinja2 import Environment, FileSystemLoader
 import yaml
+import argparse
 
 TEMPLATES_DIRNAME = "templates"
 OUTPUT_DIRNAME = "generated-readmes"
@@ -44,12 +45,11 @@ def initialize_output_dir(output_dir):
     return
 
 
-def main():
+def main(nightly_version_int, settings):
     """Generates DockerHub READMEs using Jinja2"""
 
     initialize_output_dir(OUTPUT_PATH)
 
-    settings = load_settings()
     file_loader = FileSystemLoader(TEMPLATES_DIR)
     env = Environment(loader=file_loader, lstrip_blocks=True, trim_blocks=True)
     env.filters["nightly2stable"] = lambda x: x.replace("-nightly", "")
@@ -60,7 +60,6 @@ def main():
     )
     env.filters["devel2br"] = lambda x: x.replace("-dev", "")
     template = env.get_template("base.md.j2")
-    nightly_version_int = int(settings["DEFAULT_RAPIDS_VERSION"].split(".")[1])
     for output_file in OUTPUT_READMES:
         jinja_vars = {}
         jinja_vars["repo_name"] = "rapidsai" if output_file == "ngc" else output_file
@@ -99,4 +98,18 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    settings = load_settings()
+    nightly_version_int = int(settings["DEFAULT_RAPIDS_VERSION"].split(".")[1])
+    parser = argparse.ArgumentParser(
+        description="Arguments for generating DockerHub READMEs."
+    )
+    parser.add_argument(
+        "-n",
+        type=int,
+        metavar="nightly_version",
+        dest="nightly_version",
+        help="RAPIDS nightly version as int (i.e. 18)",
+        default=nightly_version_int,
+    )
+    args = parser.parse_args()
+    main(args.nightly_version, settings)


### PR DESCRIPTION
This PR fixes an issue with the DockerHub README scripts. Currently, the `generate_readmes.py` script deduces the current RAPIDS nightly version from the `DEFAULT_RAPIDS_VERSION` value in [settings.yaml](https://github.com/rapidsai/docker/blob/branch-0.18/settings.yaml#L5). However, when merging PRs to `main` in preparation for a release, the value of `DEFAULT_RAPIDS_VERSION` should be considered the stable version instead of the nightly version.

This PR includes the following changes to fix the above issue:

- Adds a `-n` flag to `generate_readmes.py` so that the nightly value used for generating DockerHub READMEs can be overwritten. It defaults to the value in `settings.yaml`.
- Updates the `generated-files` GitHub Action to increment `DEFAULT_RAPIDS_VERSION` by 1 when testing PRs that target the `main` branch