### PR TITLE
Add gpuci_conda_retry

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
   TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  conda remove -y --force-remove treelite && \
+  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
   TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  conda remove -y --force-remove treelite && \
+  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
   TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  conda remove -y --force-remove treelite && \
+  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
   TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  conda remove -y --force-remove treelite && \
+  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
   ccache -s && \
   TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  conda remove -y --force-remove treelite && \
+  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -116,7 +116,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
 
   {% elif lib.name == "xgboost" %}
   TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  conda remove -y --force-remove treelite && \
+  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \


### PR DESCRIPTION
This PR replaces a conda command with `gpuci_conda_retry`. The absence of `gpuci_conda_retry` for this command caused a recent build failure in the `0.18` release ([link](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-core-devel/242/BUILD_IMAGE=rapidsai%2Frapidsai-core-dev,CUDA_VER=10.1,FROM_IMAGE=gpuci%2Frapidsai,IMAGE_TYPE=devel,LINUX_VER=ubuntu18.04,PYTHON_VER=3.7,RAPIDS_VER=0.18/console)).