### PR TITLE
Add start/stop Jupyter scripts

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -5,7 +5,7 @@ if [[ "${JUPYTER_FG}" == "true" ]]; then
    jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
    exit 0
 else
-   nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
+   source /rapids/utils/start-jupyter.sh > /dev/null
 
    echo "A JupyterLab server has been started!"
    echo "To access it, visit http://localhost:8888 on your host machine."

--- a/context/start-jupyter.sh
+++ b/context/start-jupyter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
+
+echo "JupyterLab server started."

--- a/context/stop-jupyter.sh
+++ b/context/stop-jupyter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pkill -f 'jupyter-lab'
+
+echo "JupyterLab servers stopped."

--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -23,8 +23,7 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 COPY libm.so.6 ${GCC7_DIR}/lib64
 
-RUN yum check-update \
-    && yum install -y \
+RUN yum install -y \
       openssh-clients
 
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -72,6 +72,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -25,8 +25,7 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 COPY libm.so.6 ${GCC7_DIR}/lib64
 
-RUN yum check-update \
-    && yum install -y \
+RUN yum install -y \
       openssh-clients
 
 
@@ -60,6 +59,8 @@ RUN cd ${RAPIDS_DIR} \
   && git submodule update --init --remote --no-single-branch --depth 1
 
 COPY test.sh /
+
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
 
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -23,8 +23,7 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 COPY libm.so.6 ${GCC7_DIR}/lib64
 
-RUN yum check-update \
-    && yum install -y \
+RUN yum install -y \
       openssh-clients
 
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -72,6 +72,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -25,8 +25,7 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 COPY libm.so.6 ${GCC7_DIR}/lib64
 
-RUN yum check-update \
-    && yum install -y \
+RUN yum install -y \
       openssh-clients
 
 
@@ -60,6 +59,8 @@ RUN cd ${RAPIDS_DIR} \
   && git submodule update --init --remote --no-single-branch --depth 1
 
 COPY test.sh /
+
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
 
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -74,6 +74,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -61,6 +61,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -74,6 +74,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -61,6 +61,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -74,6 +74,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -61,6 +61,8 @@ RUN cd ${RAPIDS_DIR} \
 
 COPY test.sh /
 
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 EXPOSE 8888
 EXPOSE 8787

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -26,6 +26,9 @@ RUN cd ${RAPIDS_DIR} \
 {# Add test file for testing notebooks from within the container #}
 COPY test.sh /
 
+{# Add jupyter start/stop scripts #}
+COPY start-jupyter.sh stop-jupyter.sh /rapids/utils/
+
 WORKDIR ${RAPIDS_DIR}/notebooks
 {# Jupyter notebook port #}
 EXPOSE 8888

--- a/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
+++ b/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
@@ -1,6 +1,5 @@
 {% if "centos" in os %}
-RUN yum check-update \
-    && yum install -y \
+RUN yum install -y \
       openssh-clients
 {% endif %}
 


### PR DESCRIPTION
This PR re-adds the `start-jupyter.sh` and `stop-jupyter.sh` scripts that existed before the Jinja2 migration. Multiple people have requested that they be re-added to our images be cause of the convenience they provide. Fixes https://github.com/rapidsai/docs/issues/160.

Additionally, it removes a call to `yum check-updates` that existed before `yum install`. The `yum check-updates` command will exit with a `100` error code if there are updates available on the machine ([src](https://access.redhat.com/solutions/2779441)). This was causing issues when trying to test these changes locally (though I'm not sure why it didn't show up in our nightly builds). From examining the `yum install` output though, it looks like `yum install` checks for updates anyway, so the explicit `yum check-updates` call shouldn't be necessary.