### PR TITLE
Revert "Remove npm patch"

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -32,6 +32,9 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && npm i -g npm@">=7"
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -46,6 +46,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && npm i -g npm@">=7"
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -35,6 +35,9 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && npm i -g npm@">=7"
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -32,6 +32,9 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && npm i -g npm@">=7"
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -46,6 +46,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && npm i -g npm@">=7"
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -35,6 +35,9 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && npm i -g npm@">=7"
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -31,6 +31,9 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && npm i -g npm@">=7"
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -48,6 +48,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && npm i -g npm@">=7"
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -34,6 +34,9 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && npm i -g npm@">=7"
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -31,6 +31,9 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && npm i -g npm@">=7"
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -48,6 +48,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && npm i -g npm@">=7"
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -34,6 +34,9 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && npm i -g npm@">=7"
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -31,6 +31,9 @@ RUN source activate rapids \
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+
+RUN source activate rapids \
+    && npm i -g npm@">=7"
 COPY packages.sh /opt/docker/bin/
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -48,6 +48,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
+    && npm i -g npm@">=7"
+
+RUN source activate rapids \
   && env \
   && conda info \
   && conda config --show-sources \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -34,6 +34,9 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
+RUN source activate rapids \
+    && npm i -g npm@">=7"
+
 RUN gpuci_conda_retry install -y -n rapids \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/templates/rapidsai-core/Base.dockerfile.j2
+++ b/templates/rapidsai-core/Base.dockerfile.j2
@@ -33,6 +33,9 @@ COPY libm.so.6 ${GCC7_DIR}/lib64
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+{# Patch for CVEs #}
+{% include 'partials/patch.dockerfile.j2' %}
+
 {# Run common commands #}
 COPY packages.sh /opt/docker/bin/
 

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -54,6 +54,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*"
 
+{# Patch for CVEs #}
+{% include 'partials/patch.dockerfile.j2' %}
+
 {% include 'partials/env_debug.dockerfile.j2' %}
 
 {% include 'partials/install_notebooks.dockerfile.j2' %}

--- a/templates/rapidsai-core/Runtime.dockerfile.j2
+++ b/templates/rapidsai-core/Runtime.dockerfile.j2
@@ -36,6 +36,9 @@ COPY libm.so.6 ${GCC7_DIR}/lib64
 RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
+{# Patch for CVEs #}
+{% include 'partials/patch.dockerfile.j2' %}
+
 {% include 'partials/install_notebooks.dockerfile.j2' %}
 
 COPY packages.sh /opt/docker/bin/

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -1,0 +1,5 @@
+{# This partial is used to install patches to resolve known CVEs #}
+
+{# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
+RUN source activate rapids \
+    && npm i -g npm@">=7"


### PR DESCRIPTION
Reverts rapidsai/docker#248

We still need to update `npm` to at least version 7 due to some CVE notices with installed `npm` pkgs. This is preventing the 0.18 hotfix images from being accepted by NGC