### PR TITLE
Remove nightly channels from stable builds

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -15,6 +15,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VE
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -19,6 +19,8 @@ ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -18,6 +18,8 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ENV RAPIDS_DIR=/rapids
 
 RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC7_DIR}/lib64

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -15,6 +15,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VE
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -19,6 +19,8 @@ ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -18,6 +18,8 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ENV RAPIDS_DIR=/rapids
 
 RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC7_DIR}/lib64

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -15,6 +15,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VE
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -19,6 +19,8 @@ ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -18,6 +18,8 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ENV RAPIDS_DIR=/rapids
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -15,6 +15,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VE
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -19,6 +19,8 @@ ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -18,6 +18,8 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ENV RAPIDS_DIR=/rapids
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -15,6 +15,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VE
 
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -19,6 +19,8 @@ ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -18,6 +18,8 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ENV RAPIDS_DIR=/rapids
 
 RUN mkdir -p ${RAPIDS_DIR}/utils 

--- a/templates/rapidsai-core/Base.dockerfile.j2
+++ b/templates/rapidsai-core/Base.dockerfile.j2
@@ -16,6 +16,9 @@ FROM ${FROM_IMAGE}:${RAPIDS_VER}-cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VE
 {# base/runtime install specs #}
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
+ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -20,6 +20,8 @@ ARG PARALLEL_LEVEL=16
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids

--- a/templates/rapidsai-core/Runtime.dockerfile.j2
+++ b/templates/rapidsai-core/Runtime.dockerfile.j2
@@ -19,6 +19,8 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+
 ENV RAPIDS_DIR=/rapids
 
 {# Copy files needed by RAPIDS and 3rd parties for builds, test, and runtime. #}


### PR DESCRIPTION
This PR removes the `nightly` channels from our `.condarc` file when building `stable` builds.