### PR TITLE
FIX Enable CUDA 11.2 CentOS 7 builds

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -40,5 +40,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.2
     LINUX_VER: ubuntu20.04
-  - CUDA_VER: 11.2        # FIXME: waiting on nvidia/cuda to release 11.2 cos7
-    LINUX_VER: centos7

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -40,5 +40,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.2
     LINUX_VER: ubuntu20.04
-  - CUDA_VER: 11.2        # FIXME: waiting on nvidia/cuda to release 11.2 cos7
-    LINUX_VER: centos7

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -39,5 +39,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.2
     LINUX_VER: ubuntu20.04
-  - CUDA_VER: 11.2        # FIXME: waiting on nvidia/cuda to release 11.2 cos7
-    LINUX_VER: centos7

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -40,5 +40,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.2
     LINUX_VER: ubuntu20.04
-  - CUDA_VER: 11.2        # FIXME: waiting on nvidia/cuda to release 11.2 cos7
-    LINUX_VER: centos7

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -39,5 +39,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.2
     LINUX_VER: ubuntu20.04
-  - CUDA_VER: 11.2        # FIXME: waiting on nvidia/cuda to release 11.2 cos7
-    LINUX_VER: centos7

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -39,5 +39,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.2
     LINUX_VER: ubuntu20.04
-  - CUDA_VER: 11.2        # FIXME: waiting on nvidia/cuda to release 11.2 cos7
-    LINUX_VER: centos7


### PR DESCRIPTION
Upstream nvidia/cuda now has CUDA 11.2 CentOS 7 builds, so we can remove the exclusions to build them now

- [x] Merge of rapidsai/gpuci-build-environment#173
- [ ] Builds of `gpuci` CUDA 11.2 CentOS 7 images deployed