### PR TITLE
Update DockerHub READMEs

### DIFF
--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -55,7 +55,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 18.04 or CentOS 7
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -28,6 +28,8 @@ The RAPIDS images provided by NGC come in two types:
 - `runtime` - extends the `base` image by adding a notebook server and example notebooks.
   - **TIP: Use this image if you want to explore RAPIDS through notebooks and examples.**
 
+For `base` and `runtime` images with Python 3.8 support or additional OS support (Ubuntu 16.04/20.04 & CentOS 8), refer to our [rapidsai/rapidsai-core](https://hub.docker.com/r/rapidsai/rapidsai-core) repo on DockerHub.
+
 For `devel` images that contain: the full RAPIDS source tree, pre-built with all artifacts in place, the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development refer to the [rapidsai/rapidsai-dev](https://hub.docker.com/repository/docker/rapidsai/rapidsai-dev) repo on DockerHub.
 
 ### Image Tag Naming Scheme
@@ -54,7 +56,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 18.04 or CentOS 7
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -56,7 +56,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 18.04 or CentOS 7
+- Ubuntu 18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -58,7 +58,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -57,7 +57,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -52,7 +52,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -51,7 +51,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -64,7 +64,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -63,7 +63,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -58,7 +58,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -57,7 +57,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -58,7 +58,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -57,7 +57,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -52,7 +52,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -51,7 +51,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -64,7 +64,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -63,7 +63,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -58,7 +58,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -57,7 +57,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -58,7 +58,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -57,7 +57,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -52,7 +52,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -51,7 +51,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -64,7 +64,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -63,7 +63,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -58,7 +58,7 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -57,7 +57,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -97,7 +97,7 @@ Many users do not need a specific platform combination but would like to ensure 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0{{ "/11.2" if is_stable }}](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 {% if is_ngc %}
-- Ubuntu 18.04 or CentOS 7
+- Ubuntu 18.04/20.04 or CentOS 7/8
 {% else %}
 - Ubuntu 16.04/18.04/20.04 or CentOS 7/8
 {% endif %}

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -57,6 +57,8 @@ The [rapidsai/{{ repo_name | devel2br }}](https://hub.docker.com/r/rapidsai/{{ r
   - **TIP: Use this image if you want to explore RAPIDS through notebooks and examples.**
 
 {% if is_ngc %}
+For `base` and `runtime` images with Python 3.8 support or additional OS support (Ubuntu 16.04/20.04 & CentOS 8), refer to our [rapidsai/rapidsai-core](https://hub.docker.com/r/rapidsai/rapidsai-core) repo on DockerHub.
+
 For `devel` images that contain: the full RAPIDS source tree, pre-built with all artifacts in place, the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development refer to the [rapidsai/rapidsai-dev](https://hub.docker.com/repository/docker/rapidsai/rapidsai-dev) repo on DockerHub.
 {% else %}
   {% if is_devel %}
@@ -94,7 +96,11 @@ Many users do not need a specific platform combination but would like to ensure 
 
 - NVIDIA Pascal™ GPU architecture or better
 - CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
-- Ubuntu 16.04/18.04 or CentOS 7
+{% if is_ngc %}
+- Ubuntu 18.04 or CentOS 7
+{% else %}
+- Ubuntu 16.04/18.04/20.04 or CentOS 7/8
+{% endif %}
 - Docker CE v18+
 - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -95,7 +95,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0{{ "/11.2" if is_stable }}](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 {% if is_ngc %}
 - Ubuntu 18.04 or CentOS 7
 {% else %}

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -95,7 +95,7 @@ Many users do not need a specific platform combination but would like to ensure 
 ## Prerequisites
 
 - NVIDIA Pascal™ GPU architecture or better
-- CUDA [10.1/10.2/11.0{{ "/11.2" if is_stable }}](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
+- CUDA [10.1/10.2/11.0/11.2](https://developer.nvidia.com/cuda-downloads) with a compatible NVIDIA driver
 {% if is_ngc %}
 - Ubuntu 18.04/20.04 or CentOS 7/8
 {% else %}


### PR DESCRIPTION
This PR updates the READMEs for DockerHub to reflect the correct image variants available in DockerHub vs. ngc.

It also adds a reference to CUDA `11.2` support.