### PR TITLE
[REVIEW] FIX Don't use a cache when building

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -44,7 +44,8 @@ if [ ! -z "$PR_ID" ] ; then
   fi
 fi
 # Setup initial BUILD_ARGS
-BUILD_ARGS="--squash \
+BUILD_ARGS="--no-cache \
+  --squash \
   --build-arg FROM_IMAGE=${FROM_IMAGE} \
   --build-arg CUDA_VER=${CUDA_VER} \
   --build-arg IMAGE_TYPE=${IMAGE_TYPE} \


### PR DESCRIPTION
Currently builds could use a cache while building, this ensures all builds are fresh.