### PR TITLE
Change shell for GH Action

### DIFF
--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Generate new Dockerfiles & READMEs
+        shell: bash
         run: |
-          #!/bin/bash
           RAPIDS_NIGHTLY_VERSION=$(grep DEFAULT_RAPIDS_VERSION settings.yaml | sed 's/.*\.//' | sed 's/[" ]//g')
           # PRs to 'main' are release PRs and therefore should consider the DEFAULT_RAPIDS_VERSION to be
           # the stable version instead of the nightly version. So the DEFAULT_RAPIDS_VERSION gets incremented here.


### PR DESCRIPTION
This PR changes the shell from `sh` to `bash` for the `generated-files.yml` GitHub Action. This should resolve the `sh: let: not found` error linked below.

https://github.com/rapidsai/docker/pull/293/checks?check_run_id=2336856577