### PR TITLE
[REVIEW] FIX Remove cached npm packages

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -41,7 +41,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -49,7 +49,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -42,7 +42,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -41,7 +41,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -49,7 +49,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -42,7 +42,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -42,7 +42,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -51,7 +51,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -43,7 +43,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -42,7 +42,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -51,7 +51,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -43,7 +43,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -42,7 +42,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -51,7 +51,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -43,7 +43,8 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -2,7 +2,8 @@
 
 {# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
 RUN source activate rapids \
-    && npm i -g npm@">=7"
+    && npm i -g npm@">=7" \
+    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
 
 {% if "centos" in os %}
 RUN yum -y upgrade \


### PR DESCRIPTION
This change removes stray folders in `/tmp` that contain cached versions of vulnerable packages that aren't caught when updating node.