### PR TITLE
Clean Jupyter Cache

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -41,8 +41,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -49,8 +49,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN yum -y upgrade \
     && yum clean all
@@ -70,7 +69,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -42,8 +42,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN yum -y upgrade \
     && yum clean all
@@ -57,7 +56,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -41,8 +41,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -49,8 +49,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN yum -y upgrade \
     && yum clean all
@@ -70,7 +69,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -42,8 +42,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN yum -y upgrade \
     && yum clean all
@@ -57,7 +56,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -42,8 +42,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -51,8 +51,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -73,7 +72,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -43,8 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -59,7 +58,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -42,8 +42,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -51,8 +51,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -73,7 +72,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -43,8 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -59,7 +58,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -42,8 +42,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -51,8 +51,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -73,7 +72,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -43,8 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -59,7 +58,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -10,7 +10,9 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard
+  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
+  && jupyter lab clean \
+  && jlpm cache clean
 
 {# Configure Dask Jupyter Lab Extension to use dask_cuda by default #}
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -2,8 +2,7 @@
 
 {# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
 RUN source activate rapids \
-    && npm i -g npm@">=7" \
-    && rm -rf /tmp/yarn* # Removes cached yarn directories from tmp that have outdated ssri/y18n packages
+    && npm i -g npm@">=7.0 <7.11"
 
 {% if "centos" in os %}
 RUN yum -y upgrade \


### PR DESCRIPTION
This PR includes the following changes:

- Adds cache clean commands (`juptyter lab clean && jlpm cache clean`) to remove vulnerable `npm` packages
- Changes the `npm` version spec since the latest version `7.11.0` has [a bug](https://github.com/npm/cli/issues/3132) that prevents builds from completing successfully