### PR TITLE
JupyterLab 3 Updates

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -66,13 +66,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -55,13 +55,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -66,13 +66,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -55,13 +55,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -69,13 +69,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -56,13 +56,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -69,13 +69,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -56,13 +56,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -69,13 +69,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -56,13 +56,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -6,14 +6,6 @@ RUN gpuci_conda_retry install -y -n rapids \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 
-{# Install jupyter lab stuff #}
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
-
-RUN source activate rapids \
-  && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard \
-  && jupyter lab clean \
-  && jlpm cache clean
-
 {# Configure Dask Jupyter Lab Extension to use dask_cuda by default #}
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"


### PR DESCRIPTION
After updating to JupyterLab 3 in https://github.com/rapidsai/jupyterlab-nvdashboard/pull/85 and https://github.com/rapidsai/integration/pull/261, the JupyterLab extensions in this PR no longer need to be installed via `jupyter labextension install` and can instead be installed solely through `conda`.


This should fix the `runtime` and `devel` build errors shown [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-core-devel/438/BUILD_IMAGE=rapidsai%2Frapidsai-core-dev-nightly,CUDA_VER=11.0,FROM_IMAGE=gpuci%2Frapidsai,IMAGE_TYPE=devel,LINUX_VER=ubuntu18.04,PYTHON_VER=3.8,RAPIDS_VER=0.20/console)

This PR depends on https://github.com/rapidsai/integration/pull/266