### PR TITLE
Remove `npm` upper version limit

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -43,7 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -49,7 +49,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -44,7 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -43,7 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -49,7 +49,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -44,7 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \
     && yum clean all

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -43,7 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -51,7 +51,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -44,7 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -43,7 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -51,7 +51,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -44,7 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -43,7 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -51,7 +51,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -44,7 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 
 
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -2,7 +2,7 @@
 
 {# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
 RUN source activate rapids \
-    && npm i -g npm@">=7.0 <7.11"
+    && npm i -g npm@">=7.0"
 
 {% if "centos" in os %}
 RUN yum -y upgrade \


### PR DESCRIPTION
The `<7.11` specifier for `npm` was introduced in #312 since `npm` version `7.11.0` had [a bug](https://github.com/npm/cli/issues/3132) at the time. The bug has since been fixed in `7.11.1`, so this upper version limit should be able to be safely removed now.