### PR TITLE
Add `libsnl` to CentOS images 

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -29,6 +29,7 @@ COPY libm.so.6 ${GCC9_DIR}/lib64
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
+      libnsl \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -32,6 +32,13 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 COPY libm.so.6 ${GCC9_DIR}/lib64
 
+RUN yum install -y \
+      openssh-clients \
+      openmpi-devel \
+      libnsl \
+      && yum clean all
+
+
 
 RUN source activate rapids \
   && env \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -30,6 +30,7 @@ COPY libm.so.6 ${GCC9_DIR}/lib64
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
+      libnsl \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -29,6 +29,7 @@ COPY libm.so.6 ${GCC9_DIR}/lib64
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
+      libnsl \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -32,6 +32,13 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 COPY libm.so.6 ${GCC9_DIR}/lib64
 
+RUN yum install -y \
+      openssh-clients \
+      openmpi-devel \
+      libnsl \
+      && yum clean all
+
+
 
 RUN source activate rapids \
   && env \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -30,6 +30,7 @@ COPY libm.so.6 ${GCC9_DIR}/lib64
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
+      libnsl \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -35,6 +35,13 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 
 
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+      openssh-client \
+      libopenmpi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+
 RUN source activate rapids \
   && env \
   && conda info \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -35,6 +35,13 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 
 
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+      openssh-client \
+      libopenmpi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+
 RUN source activate rapids \
   && env \
   && conda info \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -35,6 +35,13 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 
 
 
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+      openssh-client \
+      libopenmpi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+
 RUN source activate rapids \
   && env \
   && conda info \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -42,6 +42,8 @@ COPY nbtest.sh nbtestlog2junitxml.py ${RAPIDS_DIR}/utils/
 COPY libm.so.6 ${GCC9_DIR}/lib64
 {% endif %}
 
+{% include 'partials/os_pkgs.dockerfile.j2' %}
+
 {# Install dependencies needed for devel: build deps + RAPIDS runtime deps +
 notebook deps. This is done as a single install to ensure compatibility
 between packages. #}

--- a/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
+++ b/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
@@ -2,6 +2,7 @@
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
+      libnsl \
       && yum clean all
 {% endif %}
 


### PR DESCRIPTION
This PR adds the `libsnl` dependency to CentOS images, which is required for some `cuxfilter` notebooks to run correctly. This PR should fix the `ImportError: libnsl.so.1: cannot open shared object file: No such file or directory` error in the notebook test job log below.

https://gpuci.gpuopenanalytics.com/view/RAPIDS%20Tests%20-%20Nightly/job/rapidsai/job/nightly-tests/job/docker-test-notebooks/CUDA_VER=11.2,LINUX_VER=centos8,PYTHON_VER=3.7,RAPIDS_VER=0.20,RUNTIME_DOCKER_REPO=rapidsai%2Frapidsai-nightly/578/consoleFull