### PR TITLE
Update `cuml` build command

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -165,7 +165,7 @@ RUN cd ${RAPIDS_DIR}/cuspatial && \
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -165,7 +165,7 @@ RUN cd ${RAPIDS_DIR}/cuspatial && \
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -166,7 +166,7 @@ RUN cd ${RAPIDS_DIR}/cuspatial && \
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -166,7 +166,7 @@ RUN cd ${RAPIDS_DIR}/cuspatial && \
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -166,7 +166,7 @@ RUN cd ${RAPIDS_DIR}/cuspatial && \
 
 RUN cd ${RAPIDS_DIR}/cuml && \
   source activate rapids && \
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh --allgpuarch libcuml cuml prims
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -140,7 +140,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh --allgpuarch cugraph libcugraph
 
   {% elif lib.name == "cuml" %}
-  ./build.sh --allgpuarch --buildgtest libcuml cuml prims
+  ./build.sh --allgpuarch libcuml cuml prims
 
   {% elif lib.name == "dask-cuda"%}
   python setup.py install


### PR DESCRIPTION
This PR update the build command used for `cuml`. They recently removed the `--buildgtest` flag in the PR below.

https://github.com/rapidsai/cuml/pull/3844/files#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L42