### PR TITLE
[REVIEW] Add rapids-pytest-benchmark to devel images

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -51,9 +51,12 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
+      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*" \
+      "rmm=${RAPIDS_VER}*" \
+      "librmm=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -51,9 +51,12 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
+      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*" \
+      "rmm=${RAPIDS_VER}*" \
+      "librmm=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -53,9 +53,12 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
+      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*" \
+      "rmm=${RAPIDS_VER}*" \
+      "librmm=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -53,9 +53,12 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
+      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*" \
+      "rmm=${RAPIDS_VER}*" \
+      "librmm=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -53,9 +53,12 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
+      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*" \
+      "rmm=${RAPIDS_VER}*" \
+      "librmm=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -56,9 +56,12 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
+      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*" \
+      "rmm=${RAPIDS_VER}*" \
+      "librmm=${RAPIDS_VER}*"
 
 {# Patch for CVEs #}
 {% include 'partials/patch.dockerfile.j2' %}


### PR DESCRIPTION
Nightly tests require this package to run cugraph tests. This is a temporary change until we update to a more permanent fix in the package dependencies.