### PR TITLE
Add `21.08` to axes

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -30,6 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '21.08'
   - '21.06'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -29,5 +29,7 @@ PYTHON_VER:
   - 3.8
 
 exclude:
+  - RAPIDS_VER: '21.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -29,5 +29,7 @@ PYTHON_VER:
   - 3.8
 
 exclude:
+  - RAPIDS_VER: '21.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-clx

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -30,6 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-clx
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-clx

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '21.08'
   - '21.06'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -28,5 +28,7 @@ PYTHON_VER:
   - 3.8
 
 exclude:
+  - RAPIDS_VER: '21.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '21.08'
   - '21.06'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -29,6 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -29,5 +29,7 @@ PYTHON_VER:
   - 3.8
 
 exclude:
+  - RAPIDS_VER: '21.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-core

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '21.08'
   - '21.06'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -30,6 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-core
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-core

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -31,5 +31,7 @@ UCX_PY_VER:
   - '0.20'
 
 exclude:
+  - RAPIDS_VER: '21.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '21.08'
   - '21.06'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -29,9 +29,12 @@ PYTHON_VER:
 
 UCX_PY_VER:
   - '0.20'
+  - '0.21'
 
 exclude:
+  - RAPIDS_VER: '21.06'
+    UCX_PY_VER: '0.21'
   - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -28,5 +28,7 @@ PYTHON_VER:
   - 3.8
 
 exclude:
+  - RAPIDS_VER: '21.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
     BUILD_IMAGE: rapidsai/rapidsai-dev

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '21.08'
   - '21.06'
 
 CUDA_VER:


### PR DESCRIPTION
This PR adds `21.08` to the build axes so that the `21.08` images start building.