### PR TITLE
remove defaults channel

### DIFF
--- a/context/.condarc
+++ b/context/.condarc
@@ -4,4 +4,3 @@ channels:
   - rapidsai-nightly
   - nvidia
   - conda-forge
-  - defaults


### PR DESCRIPTION
including the defaults channel could trigger anaconda's terms of service (https://www.anaconda.com/terms-of-service), which adds complexity for the end user

$ docker run --rm rapidsai/rapidsai:0.19-cuda11.2-base-ubuntu20.04-py3.8 conda list -c | grep -e defaults -e main
defaults/linux-64::aws-sdk-cpp-1.8.151-hce553d0_0

$ docker run --rm rapidsai/rapidsai:0.19-cuda11.2-runtime-ubuntu20.04-py3.8 conda list -c | grep -e defaults -e main
defaults/linux-64::scipy-1.6.0-py38hf56f3a7_0

the aws-sdk-cpp and scipy packages have analogs in the conda-forge channel