### PR TITLE
Allow Jupyter Lab connections from any origin

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -2,7 +2,7 @@
 
 # Run Jupyter in foreground if $JUPYTER_FG is set
 if [[ "${JUPYTER_FG}" == "true" ]]; then
-   jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''
+   jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*"
    exit 0
 else
    source /rapids/utils/start-jupyter.sh > /dev/null

--- a/context/start-jupyter.sh
+++ b/context/start-jupyter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' > /dev/null 2>&1 &
+nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*" > /dev/null 2>&1 &
 
 echo "JupyterLab server started."


### PR DESCRIPTION
This is required to allow Jupyter to be accessible from behind a reverse proxy with a URL. Otherwise only localhost and IP address connections are accepted.