### PR TITLE
[REVIEW] Revert 330: Remove pytest plugin from devel

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -51,12 +51,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
-      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*" \
-      "rmm=${RAPIDS_VER}*" \
-      "librmm=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -51,12 +51,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
-      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*" \
-      "rmm=${RAPIDS_VER}*" \
-      "librmm=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -53,12 +53,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
-      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*" \
-      "rmm=${RAPIDS_VER}*" \
-      "librmm=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -53,12 +53,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
-      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*" \
-      "rmm=${RAPIDS_VER}*" \
-      "librmm=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -53,12 +53,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
-      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*" \
-      "rmm=${RAPIDS_VER}*" \
-      "librmm=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -56,12 +56,9 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
-      "rapids-pytest-benchmark" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
       "rapids-build-env=${RAPIDS_VER}*" \
-      "rapids-doc-env=${RAPIDS_VER}*" \
-      "rmm=${RAPIDS_VER}*" \
-      "librmm=${RAPIDS_VER}*"
+      "rapids-doc-env=${RAPIDS_VER}*"
 
 {# Patch for CVEs #}
 {% include 'partials/patch.dockerfile.j2' %}


### PR DESCRIPTION
Reverts #330 which was an attempt at getting pytest benchmark into the images to allow cugraph testing. Conda incorrectly was labeling `librmm` with 21.08 in the image which could result in confusion. Alternative approach is to update the conda package in the benchmark repo and install in the test script.