### PR TITLE
Prepare 21.06 release

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -3,14 +3,13 @@ BUILD_IMAGE:
   - rapidsai/rapidsai-nightly
 
 FROM_IMAGE:
-  - rapidsai/rapidsai-core-nightly
+  - rapidsai/rapidsai-core
 
 IMAGE_TYPE:
   - base
   - runtime
 
 RAPIDS_VER:
-  - '21.08'
   - '21.06'
 
 CUDA_VER:
@@ -29,7 +28,5 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai
   - RAPIDS_VER: '21.06'
-    BUILD_IMAGE: rapidsai/rapidsai
+    BUILD_IMAGE: rapidsai/rapidsai-nightly

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -3,14 +3,13 @@ BUILD_IMAGE:
   - rapidsai/rapidsai-clx-nightly
 
 FROM_IMAGE:
-  - rapidsai/rapidsai-nightly
+  - rapidsai/rapidsai
 
 IMAGE_TYPE:
   - base
   - runtime
 
 RAPIDS_VER:
-  - '21.08'
   - '21.06'
 
 CUDA_VER:
@@ -29,7 +28,5 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-clx
   - RAPIDS_VER: '21.06'
-    BUILD_IMAGE: rapidsai/rapidsai-clx
+    BUILD_IMAGE: rapidsai/rapidsai-clx-nightly

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -3,13 +3,12 @@ BUILD_IMAGE:
   - rapidsai/rapidsai-clx-dev-nightly
 
 FROM_IMAGE:
-  - rapidsai/rapidsai-dev-nightly
+  - rapidsai/rapidsai-dev
 
 IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - '21.08'
   - '21.06'
 
 CUDA_VER:
@@ -28,7 +27,5 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
   - RAPIDS_VER: '21.06'
-    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev-nightly

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - '21.08'
   - '21.06'
 
 CUDA_VER:
@@ -29,7 +28,5 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-core
   - RAPIDS_VER: '21.06'
-    BUILD_IMAGE: rapidsai/rapidsai-core
+    BUILD_IMAGE: rapidsai/rapidsai-core-nightly

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -9,7 +9,6 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - '21.08'
   - '21.06'
 
 CUDA_VER:
@@ -29,14 +28,7 @@ PYTHON_VER:
 
 UCX_PY_VER:
   - '0.20'
-  - '0.21'
 
 exclude:
   - RAPIDS_VER: '21.06'
-    UCX_PY_VER: '0.21'
-  - RAPIDS_VER: '21.08'
-    UCX_PY_VER: '0.20'
-  - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev
-  - RAPIDS_VER: '21.06'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -3,13 +3,12 @@ BUILD_IMAGE:
   - rapidsai/rapidsai-dev-nightly
 
 FROM_IMAGE:
-  - rapidsai/rapidsai-core-dev-nightly
+  - rapidsai/rapidsai-core-dev
 
 IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - '21.08'
   - '21.06'
 
 CUDA_VER:
@@ -28,7 +27,5 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: '21.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
   - RAPIDS_VER: '21.06'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-dev-nightly

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -101,7 +101,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.18 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -101,7 +101,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.18 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -104,7 +104,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.18 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -104,7 +104,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.18 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -104,7 +104,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v0.18 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/settings.yaml
+++ b/settings.yaml
@@ -27,6 +27,6 @@ RAPIDS_LIBS:
   - name: xgboost
     update_submodules: no
     repo_url: https://github.com/rapidsai/xgboost.git
-    branch: rapids-v0.18
+    branch: rapids-v21.06
   - name: dask-cuda
     repo_url: https://github.com/rapidsai/dask-cuda.git


### PR DESCRIPTION
This PR prepares `branch-21.06` for the `21.06` release. It should be merged right before we open/merge the PR from `branch-21.06` into `main`.