### PR TITLE
[REVIEW] FIX Source build rapids-pytest-benchmark

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -109,6 +109,10 @@ RUN cd ${RAPIDS_DIR} \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
+  && git clone -b main --depth 1 --single-branch https://github.com/rapidsai/benchmark.git \
+  && cd benchmark \
+  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
+  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -144,6 +148,11 @@ ENV CUDACXX="/usr/local/cuda/bin/nvcc"
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ./build.sh
+
+RUN cd ${RAPIDS_DIR}/benchmark && \
+  source activate rapids && \
+  cd rapids_pytest_benchmark && \
+  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -109,6 +109,10 @@ RUN cd ${RAPIDS_DIR} \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
+  && git clone -b main --depth 1 --single-branch https://github.com/rapidsai/benchmark.git \
+  && cd benchmark \
+  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
+  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -144,6 +148,11 @@ ENV CUDACXX="/usr/local/cuda/bin/nvcc"
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ./build.sh
+
+RUN cd ${RAPIDS_DIR}/benchmark && \
+  source activate rapids && \
+  cd rapids_pytest_benchmark && \
+  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -112,6 +112,10 @@ RUN cd ${RAPIDS_DIR} \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
+  && git clone -b main --depth 1 --single-branch https://github.com/rapidsai/benchmark.git \
+  && cd benchmark \
+  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
+  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -145,6 +149,11 @@ ENV CUDACXX="/usr/local/cuda/bin/nvcc"
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ./build.sh
+
+RUN cd ${RAPIDS_DIR}/benchmark && \
+  source activate rapids && \
+  cd rapids_pytest_benchmark && \
+  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -112,6 +112,10 @@ RUN cd ${RAPIDS_DIR} \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
+  && git clone -b main --depth 1 --single-branch https://github.com/rapidsai/benchmark.git \
+  && cd benchmark \
+  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
+  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -145,6 +149,11 @@ ENV CUDACXX="/usr/local/cuda/bin/nvcc"
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ./build.sh
+
+RUN cd ${RAPIDS_DIR}/benchmark && \
+  source activate rapids && \
+  cd rapids_pytest_benchmark && \
+  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -112,6 +112,10 @@ RUN cd ${RAPIDS_DIR} \
   && cd rmm \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
+  && git clone -b main --depth 1 --single-branch https://github.com/rapidsai/benchmark.git \
+  && cd benchmark \
+  && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
+  && cd ${RAPIDS_DIR} \
   && git clone -b ${BUILD_BRANCH} --depth 1 --single-branch https://github.com/rapidsai/cusignal.git \
   && cd cusignal \
   && git submodule update --init --remote --recursive --no-single-branch --depth 1 \
@@ -145,6 +149,11 @@ ENV CUDACXX="/usr/local/cuda/bin/nvcc"
 RUN cd ${RAPIDS_DIR}/rmm && \
   source activate rapids && \
   ./build.sh
+
+RUN cd ${RAPIDS_DIR}/benchmark && \
+  source activate rapids && \
+  cd rapids_pytest_benchmark && \
+  python setup.py install
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/settings.yaml
+++ b/settings.yaml
@@ -10,6 +10,9 @@ DEFAULT_NEXT_RAPIDS_VERSION: "21.08"
 RAPIDS_LIBS:
   - name: rmm
     repo_url: https://github.com/rapidsai/rmm.git
+  - name: benchmark
+    repo_url: https://github.com/rapidsai/benchmark.git
+    branch: main
   - name: cudf
     repo_url: https://github.com/rapidsai/cudf.git
     update_submodules: no

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -98,7 +98,11 @@ ENV CUDACXX="/usr/local/cuda/bin/nvcc"
 {% for lib in RAPIDS_LIBS %}
 RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   source activate rapids && \
-  {% if lib.name == "cudf" %}
+  {% if lib.name == "benchmark" %}
+  cd rapids_pytest_benchmark && \
+  python setup.py install
+
+  {% elif lib.name == "cudf" %}
   ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
 
   {% elif lib.name == "cuspatial" %}


### PR DESCRIPTION
Source installs rapids-pytest-benchmark to avoid installing multiple RMM packages within the rapids environment.