### PR TITLE
Remove prereq link

### DIFF
--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -9,7 +9,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -9,7 +9,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -9,7 +9,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -9,7 +9,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -9,7 +9,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -9,7 +9,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -8,7 +8,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 ### Current Version - RAPIDS v21.06

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -11,7 +11,7 @@ Visit [rapids.ai](https://rapids.ai) for more information.
 
 The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
-**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+**NOTE:** Review our prerequisites section below to ensure your system meets the minimum requirements for RAPIDS.
 
 
 {% if is_stable %}


### PR DESCRIPTION
Since the `#prerequisites` anchor link does not work on Docker Hub or NGC, remove it to avoid confusion for users.