### PR TITLE
Add openmpi-bin to Ubuntu images

### DIFF
--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
+++ b/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
@@ -11,5 +11,6 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
+      openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
 {% endif %}


### PR DESCRIPTION
The `libopenmpi-dev` package doesn't have the necessary binaries for OpenMPI, so add the binaries package.

CentOS has the necessary binaries already:
```
$ docker run -it --rm rapidsai/rapidsai-core-nightly:21.08-cuda11.0-base-centos8 find / -name mpirun
/usr/lib64/openmpi/bin/mpirun
```