### PR TITLE
[REVIEW] DOC Add documentation snippet about rapids environment

### DIFF
--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -146,6 +146,10 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -146,9 +146,9 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -150,9 +150,9 @@ Notebooks can be found in the following directories within the 21.08 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -150,6 +150,10 @@ Notebooks can be found in the following directories within the 21.08 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -144,6 +144,10 @@ Notebooks can be found in the following directories within the 21.06 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -144,9 +144,9 @@ Notebooks can be found in the following directories within the 21.06 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -156,6 +156,10 @@ Notebooks can be found in the following directories within the 21.08 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -156,9 +156,9 @@ Notebooks can be found in the following directories within the 21.08 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -150,6 +150,10 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -150,9 +150,9 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -150,9 +150,9 @@ Notebooks can be found in the following directories within the 21.08 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -150,6 +150,10 @@ Notebooks can be found in the following directories within the 21.08 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -144,6 +144,10 @@ Notebooks can be found in the following directories within the 21.06 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -144,9 +144,9 @@ Notebooks can be found in the following directories within the 21.06 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -156,6 +156,10 @@ Notebooks can be found in the following directories within the 21.08 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -156,9 +156,9 @@ Notebooks can be found in the following directories within the 21.08 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -150,6 +150,10 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -150,9 +150,9 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -150,9 +150,9 @@ Notebooks can be found in the following directories within the 21.08 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -150,6 +150,10 @@ Notebooks can be found in the following directories within the 21.08 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -144,6 +144,10 @@ Notebooks can be found in the following directories within the 21.06 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -144,9 +144,9 @@ Notebooks can be found in the following directories within the 21.06 container :
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -156,6 +156,10 @@ Notebooks can be found in the following directories within the 21.08 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -156,9 +156,9 @@ Notebooks can be found in the following directories within the 21.08 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.08/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -150,6 +150,10 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -150,9 +150,9 @@ Notebooks can be found in the following directories within the 21.06 container (
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.06/README.md) in the notebooks repository.
 
-### Building on top of RAPIDS images
+### Extending RAPIDS Images
 
-All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are available in the `rapids` conda environment. If you want to extend RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
 
 ### Custom Data and Advanced Usage
 

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -195,6 +195,10 @@ Notebooks can be found in the following directories within the {{ repo_rapids_ve
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-{{ repo_rapids_version }}/README.md) in the notebooks repository.
 
+### Building on top of RAPIDS images
+
+All RAPIDS images use `conda` as their package manager, and all RAPIDS packages (including source-built) are installed under the `rapids` environment name. If you want to build on top of the RAPIDS images (such as using `FROM`), then it is important to include `source activate rapids` at the start of all `RUN` commands in your `Dockerfile`. Without this, the docker build context will not have access to the RAPIDS libraries, as it uses the `base` environment by default. Examples of this can be found in our own Dockerfiles, which can be found in the [RAPIDS Docker Repository](https://github.com/rapidsai/docker) on GitHub.
+
 ### Custom Data and Advanced Usage
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:


### PR DESCRIPTION
Adds some documentation to help people that want to build images on top of the RAPIDS images.

People have been vocal about facing issues working with RAPIDS images and finding it difficult to properly run their commands in the right environment. Due to its generality, it is also hard to find a solution in the public domain, so directly addressing it in our README should make it easier for users who are interested in doing this.

This README is linked on our homepage under `Getting Started`, so this won't be added specifically to the site.