### PR TITLE
Update `xgboost` branch logic

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -101,7 +101,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -101,7 +101,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -105,7 +105,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -105,7 +105,7 @@ RUN cd ${RAPIDS_DIR} \
   && cd cuml \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \
-  && git clone -b rapids-v21.06 --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
+  && git clone -b branch-${RAPIDS_VER} --depth 1 --single-branch https://github.com/rapidsai/xgboost.git \
   && cd xgboost \
   && git submodule update --init --recursive --no-single-branch --depth 1 \
   && cd ${RAPIDS_DIR} \

--- a/settings.yaml
+++ b/settings.yaml
@@ -30,6 +30,5 @@ RAPIDS_LIBS:
   - name: xgboost
     update_submodules: no
     repo_url: https://github.com/rapidsai/xgboost.git
-    branch: rapids-v21.06
   - name: dask-cuda
     repo_url: https://github.com/rapidsai/dask-cuda.git

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -71,7 +71,7 @@ RUN gpuci_conda_retry install -y -n rapids \
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \
 {% for lib in RAPIDS_LIBS | sort(attribute="update_submodules") %}
-  && git clone -b {{ lib.branch | default('${BUILD_BRANCH}') }} --depth 1 --single-branch {{ lib.repo_url }} \
+  && git clone -b {{ "branch-${RAPIDS_VER}" if lib.name == "xgboost" else lib.branch | default('${BUILD_BRANCH}') }} --depth 1 --single-branch {{ lib.repo_url }} \
   && cd {{ lib.name }} \
   && git submodule update --init{{ ' --remote' if lib.update_submodules }} --recursive --no-single-branch --depth 1 {{ "\\" if not loop.last }}
   {{ "&& cd ${RAPIDS_DIR} \\" if not loop.last }}


### PR DESCRIPTION
The [rapidsai/xgboost](https://github.com/rapidsai/xgboost/tree/branch-21.08) repo's default branch name was recently updated from `rapids-v21.08` to `branch-21.08` in order to match the branch names of other RAPIDS libraries. This PR updates the Dockerfiles to use this updated branch name.