### PR TITLE
Remove `xgboost` workaround

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -182,31 +182,17 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  if [[ "$CUDA_VER" == "11.0" ]]; then \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX_STANDARD:STRING="14" \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  else \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX11_ABI=ON \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  fi
+  mkdir -p build && cd build && \
+  cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
+        -DBUILD_WITH_SHARED_NCCL=ON \
+        -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
+        -DCMAKE_CXX_STANDARD:STRING="14" \
+        -DPLUGIN_RMM=ON \
+        -DRMM_ROOT=${RAPIDS_DIR}/rmm \
+        -DCMAKE_BUILD_TYPE=release .. && \
+  make -j && make -j install && \
+  cd ../python-package && python setup.py install;
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -182,8 +182,6 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -208,8 +206,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi && \
-  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
+  fi
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -182,31 +182,17 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  if [[ "$CUDA_VER" == "11.0" ]]; then \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX_STANDARD:STRING="14" \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  else \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX11_ABI=ON \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  fi
+  mkdir -p build && cd build && \
+  cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
+        -DBUILD_WITH_SHARED_NCCL=ON \
+        -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
+        -DCMAKE_CXX_STANDARD:STRING="14" \
+        -DPLUGIN_RMM=ON \
+        -DRMM_ROOT=${RAPIDS_DIR}/rmm \
+        -DCMAKE_BUILD_TYPE=release .. && \
+  make -j && make -j install && \
+  cd ../python-package && python setup.py install;
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -182,8 +182,6 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -208,8 +206,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi && \
-  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
+  fi
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -184,31 +184,17 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  if [[ "$CUDA_VER" == "11.0" ]]; then \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX_STANDARD:STRING="14" \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  else \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX11_ABI=ON \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  fi
+  mkdir -p build && cd build && \
+  cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
+        -DBUILD_WITH_SHARED_NCCL=ON \
+        -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
+        -DCMAKE_CXX_STANDARD:STRING="14" \
+        -DPLUGIN_RMM=ON \
+        -DRMM_ROOT=${RAPIDS_DIR}/rmm \
+        -DCMAKE_BUILD_TYPE=release .. && \
+  make -j && make -j install && \
+  cd ../python-package && python setup.py install;
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -184,8 +184,6 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -210,8 +208,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi && \
-  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
+  fi
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -184,31 +184,17 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  if [[ "$CUDA_VER" == "11.0" ]]; then \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX_STANDARD:STRING="14" \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  else \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX11_ABI=ON \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  fi
+  mkdir -p build && cd build && \
+  cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
+        -DBUILD_WITH_SHARED_NCCL=ON \
+        -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
+        -DCMAKE_CXX_STANDARD:STRING="14" \
+        -DPLUGIN_RMM=ON \
+        -DRMM_ROOT=${RAPIDS_DIR}/rmm \
+        -DCMAKE_BUILD_TYPE=release .. && \
+  make -j && make -j install && \
+  cd ../python-package && python setup.py install;
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -184,8 +184,6 @@ RUN cd ${RAPIDS_DIR}/cugraph && \
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \
-  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -210,8 +208,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi && \
-  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
+  fi
 
 RUN cd ${RAPIDS_DIR}/dask-cuda && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -111,31 +111,17 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh libcuspatial cuspatial tests
 
   {% elif lib.name == "xgboost" %}
-  if [[ "$CUDA_VER" == "11.0" ]]; then \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX_STANDARD:STRING="14" \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  else \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
-          -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
-          -DBUILD_WITH_SHARED_NCCL=ON \
-          -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
-          -DCMAKE_CXX11_ABI=ON \
-          -DPLUGIN_RMM=ON \
-          -DRMM_ROOT=${RAPIDS_DIR}/rmm \
-          -DCMAKE_BUILD_TYPE=release .. && \
-    make -j && make -j install && \
-    cd ../python-package && python setup.py install; \
-  fi
+  mkdir -p build && cd build && \
+  cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DUSE_NCCL=ON -DUSE_CUDA=ON -DUSE_CUDF=ON \
+        -DBUILD_WITH_SHARED_NCCL=ON \
+        -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
+        -DCMAKE_CXX_STANDARD:STRING="14" \
+        -DPLUGIN_RMM=ON \
+        -DRMM_ROOT=${RAPIDS_DIR}/rmm \
+        -DCMAKE_BUILD_TYPE=release .. && \
+  make -j && make -j install && \
+  cd ../python-package && python setup.py install;
 
   {% elif lib.name == "cugraph" %}
   ./build.sh --allgpuarch cugraph libcugraph

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -111,8 +111,6 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh libcuspatial cuspatial tests
 
   {% elif lib.name == "xgboost" %}
-  TREELITE_VER=$(conda list -e treelite | grep -v "#" | grep "treelite=") && \
-  gpuci_conda_retry remove -y --force-remove treelite && \
   if [[ "$CUDA_VER" == "11.0" ]]; then \
     mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
@@ -137,8 +135,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
           -DCMAKE_BUILD_TYPE=release .. && \
     make -j && make -j install && \
     cd ../python-package && python setup.py install; \
-  fi && \
-  gpuci_conda_retry install -y --no-deps "${TREELITE_VER}"
+  fi
 
   {% elif lib.name == "cugraph" %}
   ./build.sh --allgpuarch cugraph libcugraph


### PR DESCRIPTION
This PR removes the temporary workaround for `xgboost` that was added in #243. It can be removed now that https://github.com/dmlc/treelite/issues/244 is closed.