### PR TITLE
Address `21.06` CVEs

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -43,7 +43,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -56,7 +56,10 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -44,7 +44,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -43,7 +43,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -56,7 +56,10 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -44,7 +44,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-base.Dockerfile
@@ -42,7 +42,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-devel.Dockerfile
@@ -58,7 +58,10 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu16.04-runtime.Dockerfile
@@ -43,7 +43,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -42,7 +42,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -58,7 +58,10 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -43,7 +43,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -42,7 +42,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -58,7 +58,10 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -43,7 +43,10 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN source activate rapids \
+RUN \
+    pip install --upgrade "cryptography>=3.3.2" \
+    && pip install --upgrade "urllib3>=1.26.5" \
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -1,7 +1,14 @@
 {# This partial is used to install patches to resolve known CVEs #}
 
-{# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
-RUN source activate rapids \
+RUN \
+{# CVE-2020-36242 https://github.com/advisories/GHSA-rhm9-p9w5-fwm7 #}
+{# Affects OS Python library, not conda environment #}
+    pip install --upgrade "cryptography>=3.3.2" \
+{# CVE-2021-33503 https://github.com/advisories/GHSA-q2q7-5pp4-w6pg #}
+{# Affects OS Python library, not conda environment #}
+    && pip install --upgrade "urllib3>=1.26.5" \
+{# CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
+    && source activate rapids \
     && npm i -g npm@">=7.0"
 
 {% if "centos" in os %}


### PR DESCRIPTION
This PR adds some temporary fixes for some CVEs that were detected in our images.

While the `pip install --upgrade` commands address the CVEs, we should ultimately update our miniconda installation version which has these CVEs addressed out of the box. This would consist of updating the `CONDA_VER` arg here: https://github.com/rapidsai/gpuci-build-environment/blob/78ba8b94ac693d7c7b408fe4ddb1097a2c37b8f1/miniconda-cuda/Dockerfile#L12-L14