### PR TITLE
Revert "Merge pull request #348 from ajschmidt8/21.06-cves"

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.Dockerfile
@@ -43,10 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -56,10 +56,7 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.Dockerfile
@@ -44,10 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.Dockerfile
@@ -43,10 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -56,10 +56,7 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.Dockerfile
@@ -44,10 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN yum -y upgrade \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.Dockerfile
@@ -43,10 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -59,10 +59,7 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.Dockerfile
@@ -44,10 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.Dockerfile
@@ -43,10 +43,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -59,10 +59,7 @@ RUN gpuci_conda_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.Dockerfile
@@ -44,10 +44,7 @@ RUN gpuci_conda_retry install -y -n rapids \
   "rapids=${RAPIDS_VER}*"
 
 
-RUN \
-    pip install --upgrade "cryptography>=3.3.2" \
-    && pip install --upgrade "urllib3>=1.26.5" \
-    && source activate rapids \
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 RUN apt-get update \

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -1,14 +1,7 @@
 {# This partial is used to install patches to resolve known CVEs #}
 
-RUN \
-{# CVE-2020-36242 https://github.com/advisories/GHSA-rhm9-p9w5-fwm7 #}
-{# Affects OS Python library, not conda environment #}
-    pip install --upgrade "cryptography>=3.3.2" \
-{# CVE-2021-33503 https://github.com/advisories/GHSA-q2q7-5pp4-w6pg #}
-{# Affects OS Python library, not conda environment #}
-    && pip install --upgrade "urllib3>=1.26.5" \
-{# CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
-    && source activate rapids \
+{# Patch for CVE-2020-8116 https://github.com/advisories/GHSA-ff7x-qrg7-qggm #}
+RUN source activate rapids \
     && npm i -g npm@">=7.0"
 
 {% if "centos" in os %}


### PR DESCRIPTION
With https://github.com/rapidsai/gpuci-build-environment/pull/198 merged and published, the manual package updates that were done in #348 are no longer necessary. This PR reverts the updates since the new version of `miniconda` includes patched versions out-of-the-box.

## Screenshot proof

![https://i.imgur.com/FyCgtqS.png](https://i.imgur.com/FyCgtqS.png)