### PR TITLE
Update `runtime`/`devel` entrypoint

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+
+# Disable automatic Jupyter launch if $DISABLE_JUPYTER is set
+if [[ "${DISABLE_JUPYTER}" =~ ^(true|yes|y)$ ]]; then
+   return 0
+
 # Run Jupyter in foreground if $JUPYTER_FG is set
-if [[ "${JUPYTER_FG}" == "true" ]]; then
+elif [[ "${JUPYTER_FG}" =~ ^(true|yes|y)$ ]]; then
    jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*"
    exit 0
 else

--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -88,7 +88,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -92,7 +92,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background 
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -86,7 +86,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background 
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -98,7 +98,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -92,7 +92,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -92,7 +92,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background 
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -86,7 +86,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background 
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -98,7 +98,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -92,7 +92,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -92,7 +92,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background 
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -86,7 +86,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background 
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -98,7 +98,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -92,7 +92,8 @@ The following ports are used by the **`runtime` containers only** (not `base` co
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background (not applicable for `base` images)
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -133,7 +133,8 @@ The following ports are used by the `devel` containers:
 
 The following environment variables can be passed to the `docker run` commands:
 
-- `JUPYTER_FG` - set to `true` to start jupyter server in foreground instead of background {{ "(not applicable for `base` images)" if is_br }}
+- `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting {{ "(not applicable for `base` images)" if is_br }}
+- `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background {{ "(not applicable for `base` images)" if is_br }}
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values


### PR DESCRIPTION
This PR updates the `runtime`/`devel` entrypoint to support a new argument, `DISABLE_JUPYTER`, which disables the default Jupyter server from running when the container starts