### PR TITLE
Add configurable timeouts to package install commands

### DIFF
--- a/context/packages.sh
+++ b/context/packages.sh
@@ -8,7 +8,7 @@ if [ "$EXTRA_APT_PACKAGES" ]; then
     fi
     echo "EXTRA_APT_PACKAGES environment variable found. Installing packages."
     apt update -y
-    apt install -y --no-install-recommends $EXTRA_APT_PACKAGES
+    timeout ${APT_TIMEOUT:-600} apt install -y --no-install-recommends $EXTRA_APT_PACKAGES
 fi
 
 if [ "$EXTRA_YUM_PACKAGES" ]; then

--- a/context/packages.sh
+++ b/context/packages.sh
@@ -7,8 +7,8 @@ if [ "$EXTRA_APT_PACKAGES" ]; then
       exit 1
     fi
     echo "EXTRA_APT_PACKAGES environment variable found. Installing packages."
-    apt update -y
-    timeout ${APT_TIMEOUT:-600} apt install -y --no-install-recommends $EXTRA_APT_PACKAGES || exit 1
+    apt update -y || exit $?
+    timeout ${APT_TIMEOUT:-600} apt install -y --no-install-recommends $EXTRA_APT_PACKAGES || exit $?
 fi
 
 if [ "$EXTRA_YUM_PACKAGES" ]; then
@@ -18,21 +18,21 @@ if [ "$EXTRA_YUM_PACKAGES" ]; then
       exit 1
     fi
     echo "EXTRA_YUM_PACKAGES environment variable found. Installing packages."
-    yum check-update -y
-    timeout ${YUM_TIMEOUT:-600} yum install -y $EXTRA_YUM_PACKAGES || exit 1
+    yum check-update -y || exit $?
+    timeout ${YUM_TIMEOUT:-600} yum install -y $EXTRA_YUM_PACKAGES || exit $?
 fi
 
 if [ -e "/opt/rapids/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    timeout ${CONDA_TIMEOUT:-600} conda env update -f /opt/rapids/environment.yml || exit 1
+    timeout ${CONDA_TIMEOUT:-600} conda env update -f /opt/rapids/environment.yml || exit $?
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found. Installing packages."
-    timeout ${CONDA_TIMEOUT:-600} conda install -y $EXTRA_CONDA_PACKAGES || exit 1
+    timeout ${CONDA_TIMEOUT:-600} conda install -y $EXTRA_CONDA_PACKAGES || exit $?
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then
     echo "EXTRA_PIP_PACKAGES environment variable found. Installing packages.".
-    timeout ${PIP_TIMEOUT:-600} pip install $EXTRA_PIP_PACKAGES || exit 1
+    timeout ${PIP_TIMEOUT:-600} pip install $EXTRA_PIP_PACKAGES || exit $?
 fi

--- a/context/packages.sh
+++ b/context/packages.sh
@@ -19,20 +19,20 @@ if [ "$EXTRA_YUM_PACKAGES" ]; then
     fi
     echo "EXTRA_YUM_PACKAGES environment variable found. Installing packages."
     yum check-update -y
-    yum install -y $EXTRA_YUM_PACKAGES
+    timeout ${YUM_TIMEOUT:-600} yum install -y $EXTRA_YUM_PACKAGES
 fi
 
 if [ -e "/opt/rapids/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    conda env update -f /opt/rapids/environment.yml
+    timeout ${CONDA_TIMEOUT:-600} conda env update -f /opt/rapids/environment.yml
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found. Installing packages."
-    conda install -y $EXTRA_CONDA_PACKAGES
+    timeout ${CONDA_TIMEOUT:-600} conda install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then
     echo "EXTRA_PIP_PACKAGES environment variable found. Installing packages.".
-    pip install $EXTRA_PIP_PACKAGES
+    timeout ${PIP_TIMEOUT:-600} pip install $EXTRA_PIP_PACKAGES
 fi

--- a/context/packages.sh
+++ b/context/packages.sh
@@ -8,7 +8,7 @@ if [ "$EXTRA_APT_PACKAGES" ]; then
     fi
     echo "EXTRA_APT_PACKAGES environment variable found. Installing packages."
     apt update -y
-    timeout ${APT_TIMEOUT:-600} apt install -y --no-install-recommends $EXTRA_APT_PACKAGES
+    timeout ${APT_TIMEOUT:-600} apt install -y --no-install-recommends $EXTRA_APT_PACKAGES || exit 1
 fi
 
 if [ "$EXTRA_YUM_PACKAGES" ]; then
@@ -19,20 +19,20 @@ if [ "$EXTRA_YUM_PACKAGES" ]; then
     fi
     echo "EXTRA_YUM_PACKAGES environment variable found. Installing packages."
     yum check-update -y
-    timeout ${YUM_TIMEOUT:-600} yum install -y $EXTRA_YUM_PACKAGES
+    timeout ${YUM_TIMEOUT:-600} yum install -y $EXTRA_YUM_PACKAGES || exit 1
 fi
 
 if [ -e "/opt/rapids/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    timeout ${CONDA_TIMEOUT:-600} conda env update -f /opt/rapids/environment.yml
+    timeout ${CONDA_TIMEOUT:-600} conda env update -f /opt/rapids/environment.yml || exit 1
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found. Installing packages."
-    timeout ${CONDA_TIMEOUT:-600} conda install -y $EXTRA_CONDA_PACKAGES
+    timeout ${CONDA_TIMEOUT:-600} conda install -y $EXTRA_CONDA_PACKAGES || exit 1
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then
     echo "EXTRA_PIP_PACKAGES environment variable found. Installing packages.".
-    timeout ${PIP_TIMEOUT:-600} pip install $EXTRA_PIP_PACKAGES
+    timeout ${PIP_TIMEOUT:-600} pip install $EXTRA_PIP_PACKAGES || exit 1
 fi

--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -91,9 +91,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -95,9 +95,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -89,9 +89,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -101,9 +101,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -95,9 +95,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -95,9 +95,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -89,9 +89,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -101,9 +101,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -95,9 +95,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -95,9 +95,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -89,9 +89,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting 
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background 
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -101,9 +101,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -95,9 +95,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting (not applicable for `base` images)
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background (not applicable for `base` images)
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -136,9 +136,13 @@ The following environment variables can be passed to the `docker run` commands:
 - `DISABLE_JUPYTER` - set to `true` to disable the default Jupyter server from starting {{ "(not applicable for `base` images)" if is_br }}
 - `JUPYTER_FG` - set to `true` to start Jupyter server in foreground instead of background {{ "(not applicable for `base` images)" if is_br }}
 - `EXTRA_APT_PACKAGES` - (**Ubuntu images only**) used to install additional `apt` packages in the container. Use a space separated list of values
+- `APT_TIMEOUT` - (**Ubuntu images only**) how long (in seconds) the `apt` command should wait before exiting
 - `EXTRA_YUM_PACKAGES` - (**CentOS images only**) used to install additional `yum` packages in the container. Use a space separated list of values
+- `YUM_TIMEOUT` - (**CentOS images only**) how long (in seconds) the `yum` command should wait before exiting
 - `EXTRA_CONDA_PACKAGES` - used to install additional `conda` packages in the container. Use a space separated list of values
+- `CONDA_TIMEOUT` - how long (in seconds) the `conda` command should wait before exiting
 - `EXTRA_PIP_PACKAGES` - used to install additional `pip` packages in the container. Use a space separated list of values
+- `PIP_TIMEOUT` - how long (in seconds) the `pip` command should wait before exiting
 
 Example:
 


### PR DESCRIPTION
Adds a timeout to each of the package install commands which default to 10 minutes but can be set with the environment variables `APT_TIMEOUT`, `YUM_TIMEOUT`, `CONDA_TIMEOUT` and `PIP_TIMEOUT`.

Possibly closes #365 