### PR TITLE
Update axes files to publish `21.12` nightlies

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -29,4 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
+    BUILD_IMAGE: rapidsai/rapidsai
+  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -29,4 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
+    BUILD_IMAGE: rapidsai/rapidsai-clx
+  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-clx

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -28,4 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
+  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -29,4 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
+    BUILD_IMAGE: rapidsai/rapidsai-core
+  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-core

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -31,4 +32,6 @@ UCX_PY_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev
+  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -28,4 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
+  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-dev


### PR DESCRIPTION
This PR updates the axes files to build and publish the `21.12` nightlies.