### PR TITLE
Remove references to `test.sh`

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -25,8 +25,6 @@ RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-COPY test.sh /
-
 RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
       "blazingsql-build-env=${RAPIDS_VER}*" \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-runtime.Dockerfile
@@ -26,8 +26,6 @@ ENV BLAZING_DIR=/blazing
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
-
-COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -25,8 +25,6 @@ RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-COPY test.sh /
-
 RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
       "blazingsql-build-env=${RAPIDS_VER}*" \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/generated-dockerfiles/rapidsai_centos8-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-runtime.Dockerfile
@@ -26,8 +26,6 @@ ENV BLAZING_DIR=/blazing
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
-
-COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -25,8 +25,6 @@ RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-COPY test.sh /
-
 RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
       "blazingsql-build-env=${RAPIDS_VER}*" \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.Dockerfile
@@ -26,8 +26,6 @@ ENV BLAZING_DIR=/blazing
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
-
-COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -25,8 +25,6 @@ RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
 
-COPY test.sh /
-
 RUN gpuci_conda_retry install -y -n rapids -c blazingsql-nightly -c blazingsql \
       "blazingsql-build-env=${RAPIDS_VER}*" \
       "rapids-build-env=${RAPIDS_VER}*" \

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.Dockerfile
@@ -26,8 +26,6 @@ ENV BLAZING_DIR=/blazing
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
-
-COPY test.sh /
 WORKDIR ${RAPIDS_DIR}
 
 

--- a/templates/rapidsai/partials/clone_blazing_notebooks.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_blazing_notebooks.dockerfile.j2
@@ -4,6 +4,3 @@
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
     && git clone https://github.com/BlazingDB/Welcome_to_BlazingSQL_Notebooks.git
-
-{# Update the test script to include BlazingSQL notebooks #}
-COPY test.sh /


### PR DESCRIPTION
The notebook testing files were removed in #362, so this PR removes a leftover `COPY` command that references the `test.sh` file that no longer exists.