### PR TITLE
Update Blazing URL

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
@@ -15,7 +15,7 @@ ENV CUDF_HOME=/rapids/cudf
 {# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
 
 {# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 not needed when using the nvidia runtime with "docker run" since the nvidia

--- a/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
@@ -15,7 +15,7 @@ ENV CUDF_HOME=/rapids/cudf
 {# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/BlazingDB/blazingsql.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging/.git
 
 {# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 not needed when using the nvidia runtime with "docker run" since the nvidia


### PR DESCRIPTION
Since the RAPIDS team has taken over maintenance of Blazing for the `21.10` release, this PR updates the URL that's used to clone Blazing in our `devel` images.