### PR TITLE
Update Blazing Clone Directory

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git blazingsql
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git blazingsql
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git blazingsql
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.Dockerfile
@@ -38,7 +38,7 @@ ENV CUDF_HOME=/rapids/cudf
 
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git blazingsql
 
 
 ENV LD_LIBRARY_PATH_ORIG=${LD_LIBRARY_PATH}

--- a/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_blazing.dockerfile.j2
@@ -15,7 +15,7 @@ ENV CUDF_HOME=/rapids/cudf
 {# Clone, build, install #}
 RUN mkdir -p ${BLAZING_DIR} \
     && cd ${BLAZING_DIR} \
-    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git
+    && git clone -b ${BUILD_BRANCH} https://github.com/rapidsai/blazingsql-release-staging.git blazingsql
 
 {# Add additional CUDA lib dir to LD_LIBRARY_PATH for "docker build".  This is
 not needed when using the nvidia runtime with "docker run" since the nvidia


### PR DESCRIPTION
This PR is a continuation of #371. Since our forked Blazing repository has a different name than the source repository, this PR ensures that the fork is cloned into a folder that has the same name as the source repository.