### PR TITLE
Remove `21.12` axis from `rapidsai` images

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
-  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -30,6 +29,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
-    BUILD_IMAGE: rapidsai/rapidsai
-  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -9,7 +9,6 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
-  - '21.12'
   - '21.10'
 
 CUDA_VER:
@@ -29,6 +28,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.10'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
-  - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-dev


### PR DESCRIPTION
Since BlazingSQL will be removed from RAPIDS in `21.12`, the `rapidsai` images (i.e. non-core images) do not need to be built for `21.12` and can therefore be removed from the axes files here.

This will prevent CI failures from occurring when trying to build/install Blazing for `21.12`.