### PR TITLE
Update `UCX_PY_VER` Value

### DIFF
--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -28,7 +28,7 @@ PYTHON_VER:
   - 3.7
 
 UCX_PY_VER:
-  - '0.21'
+  - '0.22'
 
 exclude:
   - RAPIDS_VER: '21.10'


### PR DESCRIPTION
This PR updates the `UCX_PY_VER` value for `devel` containers. The `ucx-py` version used for `branch-21.10` should be `0.22` instead of `0.21`. See https://github.com/rapidsai/cudf/pull/9099 for reference.