### PR TITLE
Update `cugraph` build step

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.Dockerfile
@@ -176,7 +176,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.Dockerfile
@@ -176,7 +176,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
@@ -178,7 +178,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.Dockerfile
@@ -178,7 +178,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -123,7 +123,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   cd ../python-package && python setup.py install;
 
   {% elif lib.name == "cugraph" %}
-  ./build.sh --allgpuarch cugraph libcugraph
+  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
 
   {% elif lib.name == "cuml" %}
   ./build.sh --allgpuarch libcuml cuml prims


### PR DESCRIPTION
This PR updates the `cugraph` build step to ensure that it also builds the new `pylibcugraph` library.