### PR TITLE
Update entrypoint scripts to have OK return code

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -16,5 +16,10 @@ else
    echo "To access it, visit http://localhost:8888 on your host machine."
    echo 'Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
       -p 8888:8888 -p 8787:8787 -p 8786:8786'
-   [ ! -d "/rapids/notebooks/host/" ] && echo "Make local folders visible by bind mounting to /rapids/notebooks/host"
+   if [ ! -d "/rapids/notebooks/host/" ]
+   then
+       echo "Make local folders visible by bind mounting to /rapids/notebooks/host"
+   else
+       :
+   fi
 fi


### PR DESCRIPTION
Fixes https://github.com/rapidsai/docker/issues/386

Example of script returning 0, and correctly printing the help text in both cases where the `/rapids/notebooks/host` folder does, and does not, exist.

```
(rapids) root@b623216d118e:/opt/docker/bin# stat /rapids/notebooks/host
stat: cannot stat '/rapids/notebooks/host': No such file or directory
(rapids) root@b623216d118e:/opt/docker/bin# bash -x entrypoint_source
+ [[ '' =~ ^(true|yes|y)$ ]]
+ [[ '' =~ ^(true|yes|y)$ ]]
+ source /rapids/utils/start-jupyter.sh
++ echo 'JupyterLab server started.'
++ nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token= '--NotebookApp.allow_origin=*'
+ echo 'A JupyterLab server has been started!'
A JupyterLab server has been started!
+ echo 'To access it, visit http://localhost:8888 on your host machine.'
To access it, visit http://localhost:8888 on your host machine.
+ echo 'Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
      -p 8888:8888 -p 8787:8787 -p 8786:8786'
Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
      -p 8888:8888 -p 8787:8787 -p 8786:8786
+ '[' '!' -d /rapids/notebooks/host/ ']'
+ echo 'Make local folders visible by bind mounting to /rapids/notebooks/host'
Make local folders visible by bind mounting to /rapids/notebooks/host
(rapids) root@b623216d118e:/opt/docker/bin# echo $?
0
(rapids) root@b623216d118e:/opt/docker/bin# mkdir /rapids/notebooks/host
(rapids) root@b623216d118e:/opt/docker/bin# bash -x entrypoint_source
+ [[ '' =~ ^(true|yes|y)$ ]]
+ [[ '' =~ ^(true|yes|y)$ ]]
+ source /rapids/utils/start-jupyter.sh
++ echo 'JupyterLab server started.'
+ echo 'A JupyterLab server has been started!'
A JupyterLab server has been started!
++ nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token= '--NotebookApp.allow_origin=*'
+ echo 'To access it, visit http://localhost:8888 on your host machine.'
To access it, visit http://localhost:8888 on your host machine.
+ echo 'Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
      -p 8888:8888 -p 8787:8787 -p 8786:8786'
Ensure the following arguments were added to "docker run" to expose the JupyterLab server to your host machine:
      -p 8888:8888 -p 8787:8787 -p 8786:8786
+ '[' '!' -d /rapids/notebooks/host/ ']'
+ :
(rapids) root@b623216d118e:/opt/docker/bin# echo $?
0
(rapids) root@b623216d118e:/opt/docker/bin#
```