### PR TITLE
Set entrypoint path as /opt/conda/bin/tini

### DIFF
--- a/generated-dockerfiles/rapidsai-clx_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-base.amd64.Dockerfile
@@ -25,6 +25,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN conda clean -afy
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.amd64.Dockerfile
@@ -49,6 +49,6 @@ RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 
 RUN conda clean -afy
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-base.amd64.Dockerfile
@@ -25,6 +25,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN conda clean -afy
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.amd64.Dockerfile
@@ -49,6 +49,6 @@ RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 
 RUN conda clean -afy
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-base.amd64.Dockerfile
@@ -25,6 +25,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN conda clean -afy
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.amd64.Dockerfile
@@ -49,6 +49,6 @@ RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 
 RUN conda clean -afy
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-base.amd64.Dockerfile
@@ -25,6 +25,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN conda clean -afy
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.amd64.Dockerfile
@@ -49,6 +49,6 @@ RUN chmod -R ugo+w /opt/conda ${CLX_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${CLX_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 
 RUN conda clean -afy
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -58,6 +58,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -209,6 +209,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -80,6 +80,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
@@ -58,6 +58,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
@@ -57,6 +57,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -209,6 +209,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -206,6 +206,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
@@ -80,6 +80,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
@@ -79,6 +79,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
@@ -59,6 +59,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
@@ -59,6 +59,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -210,6 +210,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -208,6 +208,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -81,6 +81,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -81,6 +81,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
@@ -59,6 +59,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
@@ -59,6 +59,6 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -210,6 +210,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -208,6 +208,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -81,6 +81,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -81,6 +81,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-base.amd64.Dockerfile
@@ -27,6 +27,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
@@ -59,6 +59,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-base.amd64.Dockerfile
@@ -27,6 +27,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
@@ -59,6 +59,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-base.amd64.Dockerfile
@@ -27,6 +27,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
@@ -58,6 +58,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-base.amd64.Dockerfile
@@ -27,6 +27,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
@@ -58,6 +58,6 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-runtime.amd64.Dockerfile
@@ -32,6 +32,6 @@ WORKDIR ${RAPIDS_DIR}
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR} \
   && conda clean -tipy \
   && chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${BLAZING_DIR}
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai-clx/Base.dockerfile.j2
+++ b/templates/rapidsai-clx/Base.dockerfile.j2
@@ -26,7 +26,7 @@ WORKDIR ${RAPIDS_DIR}
 RUN conda clean -afy
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai-clx/Devel.dockerfile.j2
+++ b/templates/rapidsai-clx/Devel.dockerfile.j2
@@ -27,7 +27,7 @@ WORKDIR ${RAPIDS_DIR}
 {% include 'partials/cleanup-chmod.dockerfile.j2' %}
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai-clx/Runtime.dockerfile.j2
+++ b/templates/rapidsai-clx/Runtime.dockerfile.j2
@@ -33,7 +33,7 @@ WORKDIR ${RAPIDS_DIR}
 {# Cleanup conda #}
 RUN conda clean -afy
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai-core/partials/entrypoint.dockerfile.j2
+++ b/templates/rapidsai-core/partials/entrypoint.dockerfile.j2
@@ -4,7 +4,7 @@ COPY NVIDIA_Deep_Learning_Container_License.pdf . {# Copy EULA license to workin
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 {% endif %}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai/Base.dockerfile.j2
+++ b/templates/rapidsai/Base.dockerfile.j2
@@ -26,7 +26,7 @@ WORKDIR ${RAPIDS_DIR}
 {% include 'partials/cleanup-chmod.dockerfile.j2' %}
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai/Devel.dockerfile.j2
+++ b/templates/rapidsai/Devel.dockerfile.j2
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 {% include 'partials/cleanup-chmod.dockerfile.j2' %}
 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai/Runtime.dockerfile.j2
+++ b/templates/rapidsai/Runtime.dockerfile.j2
@@ -30,7 +30,7 @@ WORKDIR ${RAPIDS_DIR}
 {# Cleanup conda and set ACLs for all users #}
 {% include 'partials/cleanup-chmod.dockerfile.j2' %}
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
As a follow up to https://github.com/rapidsai/gpuci-build-environment/pull/215, we need to update the entrpoint path to `/opt/conda/bin/tini`