### PR TITLE
Update build flags for `xgboost`

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -185,6 +185,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -185,6 +185,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -183,6 +183,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -188,6 +188,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -186,6 +186,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -188,6 +188,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -186,6 +186,7 @@ RUN cd ${RAPIDS_DIR}/xgboost && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -121,6 +121,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
         -DGDF_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_CXX_STANDARD:STRING="14" \
         -DPLUGIN_RMM=ON \
+        -DBUILD_WITH_CUDA_CUB=ON \
         -DRMM_ROOT=${RAPIDS_DIR}/rmm \
         -DCMAKE_BUILD_TYPE=release .. && \
   make -j && make -j install && \


### PR DESCRIPTION
This PR adds a new flag to the `xgboost` build command to fix the latest errors that have popped up in our `devel` builds.
