### PR TITLE
Update CLX Dockerfiles to pip install PyTorch

### DIFF
--- a/generated-dockerfiles/rapidsai-clx_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-devel.amd64.Dockerfile
@@ -30,6 +30,7 @@ RUN source activate rapids && \
         seqeval \
         python-whois \
         faker && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/generated-dockerfiles/rapidsai-clx_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos7-runtime.amd64.Dockerfile
@@ -24,6 +24,7 @@ RUN source activate rapids && \
     seqeval \
     python-whois \
     "cudatoolkit=${CUDA_VER}" && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"

--- a/generated-dockerfiles/rapidsai-clx_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-devel.amd64.Dockerfile
@@ -30,6 +30,7 @@ RUN source activate rapids && \
         seqeval \
         python-whois \
         faker && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/generated-dockerfiles/rapidsai-clx_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_centos8-runtime.amd64.Dockerfile
@@ -24,6 +24,7 @@ RUN source activate rapids && \
     seqeval \
     python-whois \
     "cudatoolkit=${CUDA_VER}" && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-devel.amd64.Dockerfile
@@ -30,6 +30,7 @@ RUN source activate rapids && \
         seqeval \
         python-whois \
         faker && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu18.04-runtime.amd64.Dockerfile
@@ -24,6 +24,7 @@ RUN source activate rapids && \
     seqeval \
     python-whois \
     "cudatoolkit=${CUDA_VER}" && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-devel.amd64.Dockerfile
@@ -30,6 +30,7 @@ RUN source activate rapids && \
         seqeval \
         python-whois \
         faker && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-clx_ubuntu20.04-runtime.amd64.Dockerfile
@@ -24,6 +24,7 @@ RUN source activate rapids && \
     seqeval \
     python-whois \
     "cudatoolkit=${CUDA_VER}" && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"

--- a/templates/rapidsai-clx/Runtime.dockerfile.j2
+++ b/templates/rapidsai-clx/Runtime.dockerfile.j2
@@ -24,6 +24,7 @@ RUN source activate rapids && \
     seqeval \
     python-whois \
     "cudatoolkit=${CUDA_VER}" && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install wget && \
     pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"

--- a/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
+++ b/templates/rapidsai-clx/partials/clone_and_build_clx.dockerfile.j2
@@ -11,6 +11,7 @@ RUN source activate rapids && \
         seqeval \
         python-whois \
         faker && \
+    pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \


### PR DESCRIPTION
- Update PyTorch 1.7.1 to latest stable (1.10). 
- pip install latest stable PyTorch (v1.10) in `base` and `devel` images. Replaces conda install of PyTorch 1.7.1 which was tying us to CUDA 11.0. conda and mamba would often install cpu version of PyTorch on RAPIDS-supported CUDA versions.
- Fixes `runtime` containers which had cpu PyTorch installed.
