### PR TITLE
Update axes to release `22.02` images

### DIFF
--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -11,6 +11,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
+  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -30,4 +31,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
+    BUILD_IMAGE: rapidsai/rapidsai-clx
+  - RAPIDS_VER: '22.02'
     BUILD_IMAGE: rapidsai/rapidsai-clx

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
+  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -26,4 +27,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
+  - RAPIDS_VER: '22.02'
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev

--- a/ci/axis/rapidsai-core-base-runtime-arm64.yaml
+++ b/ci/axis/rapidsai-core-base-runtime-arm64.yaml
@@ -11,6 +11,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
+  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -28,4 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
+    BUILD_IMAGE: rapidsai/rapidsai-core-arm64
+  - RAPIDS_VER: '22.02'
     BUILD_IMAGE: rapidsai/rapidsai-core-arm64

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -11,6 +11,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
+  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -30,4 +31,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
+    BUILD_IMAGE: rapidsai/rapidsai-core
+  - RAPIDS_VER: '22.02'
     BUILD_IMAGE: rapidsai/rapidsai-core

--- a/ci/axis/rapidsai-core-devel-arm64.yaml
+++ b/ci/axis/rapidsai-core-devel-arm64.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
+  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -28,4 +29,6 @@ UCX_PY_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64
+  - RAPIDS_VER: '22.02'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
+  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -29,4 +30,6 @@ UCX_PY_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev
+  - RAPIDS_VER: '22.02'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev


### PR DESCRIPTION
This PR updates the axes to release `22.02` images.