### PR TITLE
Add `DASK_SQL_VER` Docker build argument

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -61,6 +61,7 @@ BUILD_ARGS="--no-cache \
   --build-arg CUDA_VER=${CUDA_VER} \
   --build-arg IMAGE_TYPE=${IMAGE_TYPE} \
   --build-arg LINUX_VER=${LINUX_VER} \
+  --build-arg DASK_SQL_VER=${DASK_SQL_VER} \
   --build-arg UCX_PY_VER=${UCX_PY_VER}"
 # Add BUILD_BRANCH arg for 'main' branch only
 if [ "${BUILD_BRANCH}" = "main" ]; then


### PR DESCRIPTION
This PR adds the `DASK_SQL_VER` build argument, which is currently absent and therefore causing issues when trying to clone the `dask-sql` repository in our Docker builds.

The `DASK_SQL_VER` is populated via the matrix configuration files (i.e. `ci/axis/rapids-devel.yaml`).