### PR TITLE
Prepare Axis Files for Release

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -11,7 +11,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 DASK_SQL_VER:
   - '0.4.0'
@@ -34,6 +33,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai
+    BUILD_IMAGE: rapidsai/rapidsai-nightly

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -11,7 +11,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -31,6 +30,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-clx
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-clx
+    BUILD_IMAGE: rapidsai/rapidsai-clx-nightly

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -27,6 +26,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev-nightly

--- a/ci/axis/rapidsai-core-base-runtime-arm64.yaml
+++ b/ci/axis/rapidsai-core-base-runtime-arm64.yaml
@@ -11,7 +11,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -29,6 +28,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-core-arm64
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-core-arm64
+    BUILD_IMAGE: rapidsai/rapidsai-core-nightly-arm64

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -11,7 +11,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -31,6 +30,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-core
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-core
+    BUILD_IMAGE: rapidsai/rapidsai-core-nightly

--- a/ci/axis/rapidsai-core-devel-arm64.yaml
+++ b/ci/axis/rapidsai-core-devel-arm64.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -29,6 +28,4 @@ UCX_PY_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly-arm64

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 CUDA_VER:
   - 11.5
@@ -30,6 +29,4 @@ UCX_PY_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -10,7 +10,6 @@ IMAGE_TYPE:
 
 RAPIDS_VER:
   - '21.12'
-  - '22.02'
 
 DASK_SQL_VER:
   - '0.4.0'
@@ -30,6 +29,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '21.12'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
-  - RAPIDS_VER: '22.02'
-    BUILD_IMAGE: rapidsai/rapidsai-dev
+    BUILD_IMAGE: rapidsai/rapidsai-dev-nightly

--- a/dockerhub-readme/generated-readmes/ngc.md
+++ b/dockerhub-readme/generated-readmes/ngc.md
@@ -147,6 +147,7 @@ Notebooks can be found in the following directories within the 21.10 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev-nightly.md
@@ -151,6 +151,7 @@ Notebooks can be found in the following directories within the 21.12 container :
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.12/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-dev.md
@@ -145,6 +145,7 @@ Notebooks can be found in the following directories within the 21.10 container :
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx-nightly.md
@@ -157,6 +157,7 @@ Notebooks can be found in the following directories within the 21.12 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.12/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-clx.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-clx.md
@@ -151,6 +151,7 @@ Notebooks can be found in the following directories within the 21.10 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev-nightly.md
@@ -151,6 +151,7 @@ Notebooks can be found in the following directories within the 21.12 container :
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.12/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-dev.md
@@ -145,6 +145,7 @@ Notebooks can be found in the following directories within the 21.10 container :
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core-nightly.md
@@ -157,6 +157,7 @@ Notebooks can be found in the following directories within the 21.12 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.12/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-core.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-core.md
@@ -151,6 +151,7 @@ Notebooks can be found in the following directories within the 21.10 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev-nightly.md
@@ -151,6 +151,7 @@ Notebooks can be found in the following directories within the 21.12 container :
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.12/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-dev.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-dev.md
@@ -145,6 +145,7 @@ Notebooks can be found in the following directories within the 21.10 container :
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai-nightly.md
+++ b/dockerhub-readme/generated-readmes/rapidsai-nightly.md
@@ -157,6 +157,7 @@ Notebooks can be found in the following directories within the 21.12 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.12/README.md) in the notebooks repository.

--- a/dockerhub-readme/generated-readmes/rapidsai.md
+++ b/dockerhub-readme/generated-readmes/rapidsai.md
@@ -151,6 +151,7 @@ Notebooks can be found in the following directories within the 21.10 container (
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-21.10/README.md) in the notebooks repository.

--- a/dockerhub-readme/templates/base.md.j2
+++ b/dockerhub-readme/templates/base.md.j2
@@ -192,6 +192,7 @@ Notebooks can be found in the following directories within the {{ repo_rapids_ve
 * `/rapids/notebooks/cuml` - cuML demo notebooks
 * `/rapids/notebooks/cusignal` - cuSignal demo notebooks
 * `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/cuspatial` - cuSpatial demo notebooks
 * `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
 For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-{{ repo_rapids_version }}/README.md) in the notebooks repository.


### PR DESCRIPTION
This PR updates the axis files for the release. It removes `22.02` from the axes and adds `-nightly` to the `excludes` so that the resulting image names do not have the `-nightly` suffix.

Hold off on merging this until we're ready to release the images.