### PR TITLE
Backport #413 to `branch-21.12`

### DIFF
--- a/ci/axis/rapidsai-core-devel-arm64.yaml
+++ b/ci/axis/rapidsai-core-devel-arm64.yaml
@@ -23,9 +23,6 @@ PYTHON_VER:
   - 3.8
   - 3.7
 
-UCX_PY_VER:
-  - '0.23'
-
 exclude:
   - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly-arm64

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -24,9 +24,6 @@ PYTHON_VER:
   - 3.8
   - 3.7
 
-UCX_PY_VER:
-  - '0.23'
-
 exclude:
   - RAPIDS_VER: '21.12'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -61,8 +61,7 @@ BUILD_ARGS="--no-cache \
   --build-arg CUDA_VER=${CUDA_VER} \
   --build-arg IMAGE_TYPE=${IMAGE_TYPE} \
   --build-arg LINUX_VER=${LINUX_VER} \
-  --build-arg DASK_SQL_VER=${DASK_SQL_VER} \
-  --build-arg UCX_PY_VER=${UCX_PY_VER}"
+  --build-arg DASK_SQL_VER=${DASK_SQL_VER}"
 # Add BUILD_BRANCH arg for 'main' branch only
 if [ "${BUILD_BRANCH}" = "main" ]; then
   BUILD_ARGS+=" --build-arg BUILD_BRANCH=${BUILD_BRANCH}"
@@ -82,6 +81,10 @@ else
   echo "RAPIDS_VER is set to '$RAPIDS_VER', adding to build args..."
   BUILD_ARGS+=" --build-arg RAPIDS_VER=${RAPIDS_VER}"
   BUILD_TAG="${RAPIDS_VER}-${BUILD_TAG}" #pre-prend version number
+  echo "Fetch ucx-py version from rvc"
+  UCX_PY_VER="$(curl -sL https://version.gpuci.io/rapids/${RAPIDS_VER})"
+  echo "UCX_PY_VER is set to '${UCX_PY_VER}', adding to build args..."
+  BUILD_ARGS+=" --build-arg UCX_PY_VER=${UCX_PY_VER}"
 fi
 
 # Ouput build config


### PR DESCRIPTION
After #413 was merged, the Jenkins jobs had to be updated to remove `UCX_PY_VER` from the axis. Therefore, `branch-21.12` builds stopped working. This PR should resolve that by backporting #413 to `branch-21.12`.

The `generated-files` check is expected to failed on this PR.