### PR TITLE
Fix package specifications

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -38,7 +38,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -44,7 +44,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
@@ -67,7 +67,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -50,7 +50,7 @@ RUN yum -y upgrade \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
@@ -38,7 +38,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
@@ -38,7 +38,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -44,7 +44,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
@@ -67,7 +67,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -44,7 +44,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
@@ -65,7 +65,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -50,7 +50,7 @@ RUN yum -y upgrade \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -50,7 +50,7 @@ RUN yum -y upgrade \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -48,7 +48,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
@@ -72,7 +72,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -48,7 +48,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
@@ -70,7 +70,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -40,7 +40,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -52,7 +52,7 @@ RUN apt-get update \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -40,7 +40,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -52,7 +52,7 @@ RUN apt-get update \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
@@ -39,7 +39,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -48,7 +48,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
@@ -72,7 +72,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -48,7 +48,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
@@ -70,7 +70,7 @@ RUN source activate rapids \
   && conda list --show-channel-urls
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -40,7 +40,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -52,7 +52,7 @@ RUN apt-get update \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -40,7 +40,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 
 RUN source activate rapids \
@@ -52,7 +52,7 @@ RUN apt-get update \
 
 
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/templates/rapidsai-core/Base.dockerfile.j2
+++ b/templates/rapidsai-core/Base.dockerfile.j2
@@ -31,7 +31,7 @@ RUN mkdir -p ${RAPIDS_DIR}/utils {{ "${GCC9_DIR}/lib64" if "centos" in os }}
 {% include 'partials/env_debug.dockerfile.j2' %}
 
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 {# Patch for CVEs #}
 {% include 'partials/patch.dockerfile.j2' %}

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -47,7 +47,7 @@ between packages. #}
 {# Install rapids env pkg #}
 {% if "amd64" in arch %}
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "rapids-doc-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
@@ -56,7 +56,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
       "rapids-doc-env=${RAPIDS_VER}*"
 {% elif "arm64" in arch %}
 RUN gpuci_mamba_retry install -y -n rapids \
-      "rapids-build-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+      "rapids-build-env=${RAPIDS_VER}*" \
       "libcumlprims=${RAPIDS_VER}*" \
       "ucx-py=${UCX_PY_VER}.*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/templates/rapidsai-core/Runtime.dockerfile.j2
+++ b/templates/rapidsai-core/Runtime.dockerfile.j2
@@ -32,7 +32,7 @@ RUN mkdir -p ${RAPIDS_DIR}/utils {{ "${GCC9_DIR}/lib64" if "centos" in os }}
 {% include 'partials/env_debug.dockerfile.j2' %}
 
 RUN gpuci_mamba_retry install -y -n rapids \
-  "rapids=${RAPIDS_VER}*=cuda${CUDA_VER}*"
+  "rapids=${RAPIDS_VER}*"
 
 {# Patch for CVEs #}
 {% include 'partials/patch.dockerfile.j2' %}

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -2,7 +2,7 @@
 
 {# Install the rapids-notebook-env meta-pkg #}
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*=cuda${CUDA_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 


### PR DESCRIPTION
After https://github.com/rapidsai/integration/pull/411 was merged, the build string for our meta-packages changed from `cuda11.5*` to just `cuda11*`. This change caused our Docker builds to stop working.

Since we now build with CUDA Enhanced Compatibility, I think it should be fine to drop the `=cuda` spec from the strings below. However, an alternative would be to include the `cudatoolkit` spec as shown below, but I don't think that's necessary. 


```sh
gpuci_mamba_retry install -n rapids \
  "rapids-notebook-env=${RAPIDS_VER}" \
  "cudatoolkit=${CUDA_VER}*" \
  && gpuci_conda_retry remove -y -n rapids --force-remove \
  "rapids-notebook-env=${RAPIDS_VER}*"
```

@Ethyling, any thoughts here?