### PR TITLE
Run Jupyter in foreground if non-interactive

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -5,8 +5,8 @@
 if [[ "${DISABLE_JUPYTER}" =~ ^(true|yes|y)$ ]]; then
    return 0
 
-# Run Jupyter in foreground if $JUPYTER_FG is set
-elif [[ "${JUPYTER_FG}" =~ ^(true|yes|y)$ ]]; then
+# Run Jupyter in foreground if $JUPYTER_FG is set or container is running non-interactively
+elif [[ "${JUPYTER_FG}" =~ ^(true|yes|y)$ ]] || ! [ -t 0 ]; then
    jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*"
    exit 0
 else
@@ -20,3 +20,4 @@ else
        echo "Make local folders visible by bind mounting to /rapids/notebooks/host"
    fi
 fi
+


### PR DESCRIPTION
When you run the RAPIDS runtime docker images interactively they start Jupyter as a background process and drop you into a bash shell which is nice for folks running the container via the CLI interactively.

However when trying to use the Docker image non-interactively in services like Binder, Kubeflow, Kubernetes, Dask Clusters, etc this is a bit of a hinderance. A while back we added a `JUPYTER_FG` env flag to run Jupyter in the foreground and a `DISABLE_JUPYTER` env flag to disable Jupyter all together. These workarounds are useful but it would be really great for the docker image to run successfully in a non-interactive environment without additional configuration.

**Reproducer**

```console
$ docker run --rm rapidsai/rapidsai-core:21.12-cuda11.5-runtime-ubuntu20.04-py3.8
# Exits immediately

$ docker run --rm -it rapidsai/rapidsai-core:21.12-cuda11.5-runtime-ubuntu20.04-py3.8
# Drops you into a bash shell
```

---

This PR adds a check for an attached tty and switches the default `JUPYTER_FG` behaviour when used non-interactively.

**New behaviour**

```console
$ docker run --rm rapidsai/rapidsai-core:21.12-cuda11.5-runtime-ubuntu20.04-py3.8
# Runs Jupyter lab as the foreground service

$ docker run --rm -it rapidsai/rapidsai-core:21.12-cuda11.5-runtime-ubuntu20.04-py3.8
# Still drops you into a bash shell as expected
```

This way we don't have to set the `JUPYTER_FG` flag on systems where this is tricky (Kubeflow and NGC are examples where setting env vars is non-trivial).