### PR TITLE
Handle NB_PREFIX in Jupyter startup

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -7,7 +7,7 @@ if [[ "${DISABLE_JUPYTER}" =~ ^(true|yes|y)$ ]]; then
 
 # Run Jupyter in foreground if $JUPYTER_FG is set
 elif [[ "${JUPYTER_FG}" =~ ^(true|yes|y)$ ]]; then
-   jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*"
+   jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*" --NotebookApp.base_url="${NB_PREFIX:-/}"
    exit 0
 else
    source /rapids/utils/start-jupyter.sh > /dev/null

--- a/context/start-jupyter.sh
+++ b/context/start-jupyter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*" > /dev/null 2>&1 &
+nohup jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin="*" --NotebookApp.base_url="${NB_PREFIX:-/}" > /dev/null 2>&1 &
 
 echo "JupyterLab server started."


### PR DESCRIPTION
Some spawning environments such as [the one used in Kubeflow](https://www.kubeflow.org/docs/components/notebooks/container-images/#image-requirements) expect to set an `NB_PREFIX` environment variable when proxying the Jupyter server so that Jupyter handles requests correctly.

Updating the `jupyter lab` command to handle this.