### PR TITLE
Remove `dask` development channel for release builds

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
@@ -18,7 +18,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/templates/rapidsai-core/Base.dockerfile.j2
+++ b/templates/rapidsai-core/Base.dockerfile.j2
@@ -19,7 +19,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -22,7 +22,7 @@ ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ARG PYTHON_VER
 

--- a/templates/rapidsai-core/Runtime.dockerfile.j2
+++ b/templates/rapidsai-core/Runtime.dockerfile.j2
@@ -20,7 +20,7 @@ ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
 
-RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d' /opt/conda/.condarc; fi
+RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
 
 ENV RAPIDS_DIR=/rapids
 


### PR DESCRIPTION
This PR is required for https://github.com/rapidsai/gpuci-build-environment/pull/238, which adds a `dask` development channel for nightly builds.