### PR TITLE
Update dask-sql build commands

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
+    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
+    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
+    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
+    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
@@ -14,4 +14,5 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
+    && python setup.py java \
     && python -m pip install . --no-deps -vv


### PR DESCRIPTION
Once https://github.com/dask-contrib/dask-sql/pull/396 is merged in, the build commands for dask-sql will change so that the Java extensions must be built separately from the `pip` install. This PR updates the build commands for the `devel` images accordingly.

