### PR TITLE
Update dask-sql build command for `devel` images

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
@@ -32,7 +32,6 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
@@ -32,7 +32,6 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
@@ -32,7 +32,6 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
@@ -32,7 +32,6 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python setup.py java \
     && python -m pip install . --no-deps -vv
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \

--- a/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
@@ -14,5 +14,4 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python setup.py java \
     && python -m pip install . --no-deps -vv


### PR DESCRIPTION
With https://github.com/dask-contrib/dask-sql/pull/406, we should be able to consolidate the build command for dask-sql so that we no longer need to run `python setup.py java` for a source installation.

Needs https://github.com/dask-contrib/dask-sql/pull/406