### PR TITLE
Remove `~/.m2` directory after `dask-sql` source build

### DIFF
--- a/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python -m pip install . --no-deps -vv
+    && python -m pip install . --no-deps -vv \
+    && rm -rf ~/.m2
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \
   && conda clean -tipy \

--- a/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos8-devel.amd64.Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python -m pip install . --no-deps -vv
+    && python -m pip install . --no-deps -vv \
+    && rm -rf ~/.m2
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \
   && conda clean -tipy \

--- a/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu18.04-devel.amd64.Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python -m pip install . --no-deps -vv
+    && python -m pip install . --no-deps -vv \
+    && rm -rf ~/.m2
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \
   && conda clean -tipy \

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python -m pip install . --no-deps -vv
+    && python -m pip install . --no-deps -vv \
+    && rm -rf ~/.m2
 
 RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} ${DASK_SQL_DIR} \
   && conda clean -tipy \

--- a/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
@@ -14,4 +14,5 @@ RUN mkdir -p ${DASK_SQL_DIR} \
 
 RUN source activate rapids \
     && cd ${DASK_SQL_DIR}/dask-sql \
-    && python -m pip install . --no-deps -vv
+    && python -m pip install . --no-deps -vv \
+    && rm -rf ~/.m2


### PR DESCRIPTION
This PR removes the `~/.m2` directory from the images after the `dask-sql` source build. This change is necessary because the `~/.m2` directory contains `log4j`, which triggers some security alerts for our images. As per @jdye64, the `log4j` dependency is only used during the compile steps (and is not in the resulting `DaskSQL.jar` file) and is therefore safe to simply remove with `rm -rf ~/.m2`.