### PR TITLE
[HOTFIX] Backport #437 to `branch-22.02`

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -74,7 +74,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -57,7 +57,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -74,7 +74,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -72,7 +72,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
@@ -57,7 +57,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
@@ -57,7 +57,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -79,7 +79,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -77,7 +77,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -59,7 +59,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -59,7 +59,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -79,7 +79,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -77,7 +77,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -59,7 +59,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -59,7 +59,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -11,7 +11,7 @@ ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 {# Install jupyter lab stuff #}
-RUN gpuci_conda_retry install -y -n rapids jupyterlab-nvdashboard
+RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard
 
 {# Install notebooks repo #}
 RUN cd ${RAPIDS_DIR} \


### PR DESCRIPTION
This PR backports #437 to `branch-22.02` to help resolve/deubg some `conda` conflicts that occur when installing `jupyterlab-nvdashboard`.