### PR TITLE
Set the default PATH to include the RAPIDS conda env

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -58,6 +58,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -234,6 +234,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -83,6 +83,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
@@ -58,6 +58,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
@@ -58,6 +58,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -234,6 +234,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -232,6 +232,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
@@ -83,6 +83,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
@@ -83,6 +83,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
@@ -60,6 +60,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
@@ -60,6 +60,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -236,6 +236,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -234,6 +234,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -85,6 +85,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -85,6 +85,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
@@ -60,6 +60,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
@@ -60,6 +60,9 @@ WORKDIR ${RAPIDS_DIR}
 
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -236,6 +236,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -234,6 +234,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -85,6 +85,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -85,6 +85,9 @@ RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR} \
 COPY NVIDIA_Deep_Learning_Container_License.pdf . 
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 CMD [ "/bin/bash" ]

--- a/templates/rapidsai-core/partials/entrypoint.dockerfile.j2
+++ b/templates/rapidsai-core/partials/entrypoint.dockerfile.j2
@@ -4,6 +4,10 @@ COPY NVIDIA_Deep_Learning_Container_License.pdf . {# Copy EULA license to workin
 COPY source_entrypoints/runtime_devel.sh /opt/docker/bin/entrypoint_source
 {% endif %}
 COPY entrypoint.sh /opt/docker/bin/entrypoint
+
+{# Set the default PATH to include the RAPIDS conda env #}
+ENV "PATH=/opt/conda/envs/rapids/bin:/opt/conda/condabin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 
 {# Set the default command to pass to the ENTRYPOINT if no command was given #}


### PR DESCRIPTION
As a workaround for issues raised in #438 and #439 this PR sets the `PATH` explicitly to include the RAPIDS conda environment.

Many container platforms including Kubernetes override the default entrypoint, so this change ensures binaries like `jupyter` are still on the path even without the entrypoint being run. Also when calling `docker exec` on a container the environment is not copied from the main process and without the entrypoint the path is also wrong.