### PR TITLE
exec jupyter kernelspec and ipykernel commands

### DIFF
--- a/context/source_entrypoints/runtime_devel.sh
+++ b/context/source_entrypoints/runtime_devel.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [[ "$@" = *"ipykernel"* ]]; then
+   return 0
+fi
+
+if [[ "$@" = *"jupyter kernelspec"* ]]; then
+   return 0
+fi
+
 
 # Disable automatic Jupyter launch if $DISABLE_JUPYTER is set
 if [[ "${DISABLE_JUPYTER}" =~ ^(true|yes|y)$ ]]; then


### PR DESCRIPTION
This PR adds exceptions for `jupyter kernelspec` and `ipykernel` commands to be executed in runnable docker configurations like the following:

> docker run --rm --name foobar quasiben/vertexai-exec:1 /opt/conda/envs/rapids/bin/python -m ipykernel_launcher foobar
> docker run --rm --name foobar quasiben/vertexai-exec:1 jupyter kernelspec list --json

---

This PR is just #466 cut from `branch-22.04`.