### PR TITLE
`apt` key fix

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,15 +29,15 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-
-RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC9_DIR}/lib64
-
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
       && yum clean all
 
+
+
+RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC9_DIR}/lib64
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.amd64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-base.arm64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.amd64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,15 +29,15 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-
-RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC9_DIR}/lib64
-
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
       && yum clean all
 
+
+
+RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC9_DIR}/lib64
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-devel.arm64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,15 +29,15 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-
-RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC9_DIR}/lib64
-
 RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
       && yum clean all
 
+
+
+RUN mkdir -p ${RAPIDS_DIR}/utils ${GCC9_DIR}/lib64
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.amd64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos8-runtime.arm64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -26,7 +27,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -26,7 +27,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,19 +29,20 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gsfonts \
-    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p ${RAPIDS_DIR}/utils 
-
-
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
       openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gsfonts \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,19 +29,20 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gsfonts \
-    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p ${RAPIDS_DIR}/utils 
-
-
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
       openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gsfonts \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -27,7 +28,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -27,7 +28,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -26,7 +27,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
@@ -17,6 +17,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -26,7 +27,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,19 +29,20 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gsfonts \
-    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p ${RAPIDS_DIR}/utils 
-
-
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
       openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gsfonts \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -20,6 +20,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,19 +29,20 @@ ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gsfonts \
-    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p ${RAPIDS_DIR}/utils 
-
-
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \
       openmpi-bin \
     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gsfonts \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
 RUN source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -27,7 +28,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -27,7 +28,8 @@ ENV RAPIDS_DIR=/rapids
 RUN mkdir -p ${RAPIDS_DIR}/utils 
 
 
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \

--- a/templates/rapidsai-core/Base.dockerfile.j2
+++ b/templates/rapidsai-core/Base.dockerfile.j2
@@ -18,6 +18,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -21,6 +21,7 @@ ARG RAPIDS_VER
 ARG CUDA_VER
 ARG UCX_PY_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi
@@ -28,6 +29,8 @@ RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev
 ARG PYTHON_VER
 
 ENV RAPIDS_DIR=/rapids
+
+{% include 'partials/os_pkgs.dockerfile.j2' %}
 
 {% if "ubuntu" in os %}
 {# gsfonts is used to correctly render fonts in doxygen/graphviz diagrams #}
@@ -37,8 +40,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 {% endif %}
 
 RUN mkdir -p ${RAPIDS_DIR}/utils {{ "${GCC9_DIR}/lib64" if "centos" in os }}
-
-{% include 'partials/os_pkgs.dockerfile.j2' %}
 
 {# Install dependencies needed for devel: build deps + RAPIDS runtime deps +
 notebook deps. This is done as a single install to ensure compatibility

--- a/templates/rapidsai-core/Runtime.dockerfile.j2
+++ b/templates/rapidsai-core/Runtime.dockerfile.j2
@@ -19,6 +19,7 @@ ARG CUDA_VER
 ARG DASK_XGBOOST_VER=0.2*
 ARG RAPIDS_VER
 ARG BUILD_BRANCH="branch-${RAPIDS_VER}"
+ARG LINUX_VER
 ENV RAPIDS_VER=$RAPIDS_VER
 
 RUN if [ "${BUILD_BRANCH}" = "main" ]; then sed -i '/nightly/d;/dask\/label\/dev/d' /opt/conda/.condarc; fi

--- a/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
+++ b/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
@@ -7,7 +7,8 @@ RUN yum install -y \
 {% endif %}
 
 {% if "ubuntu" in os %}
-RUN apt-get update \
+RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/$(uname -p)/3bf863cc.pub" \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
       openssh-client \
       libopenmpi-dev \


### PR DESCRIPTION
This PR backports the recent `apt` key fix that we implemented in https://github.com/rapidsai/gpuci-build-environment/pull/255 to the stable `22.04` images.