### PR TITLE
Update axes to build `22.10` images

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 DASK_SQL_VER:
@@ -33,4 +34,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai

--- a/ci/axis/rapidsai-clx-base-runtime.yaml
+++ b/ci/axis/rapidsai-clx-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 CUDA_VER:
@@ -30,4 +31,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-clx
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-clx

--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 CUDA_VER:
@@ -26,4 +27,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-clx-dev
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-clx-dev

--- a/ci/axis/rapidsai-core-base-runtime-arm64.yaml
+++ b/ci/axis/rapidsai-core-base-runtime-arm64.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 CUDA_VER:
@@ -28,4 +29,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-core-arm64
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-core-arm64

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -10,6 +10,7 @@ IMAGE_TYPE:
   - runtime
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 CUDA_VER:
@@ -30,4 +31,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-core
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-core

--- a/ci/axis/rapidsai-core-devel-arm64.yaml
+++ b/ci/axis/rapidsai-core-devel-arm64.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 CUDA_VER:
@@ -25,4 +26,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 CUDA_VER:
@@ -26,4 +27,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-core-dev

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -9,6 +9,7 @@ IMAGE_TYPE:
   - devel
 
 RAPIDS_VER:
+  - '22.10'
   - '22.08'
 
 DASK_SQL_VER:
@@ -29,4 +30,6 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '22.08'
+    BUILD_IMAGE: rapidsai/rapidsai-dev
+  - RAPIDS_VER: '22.10'
     BUILD_IMAGE: rapidsai/rapidsai-dev


### PR DESCRIPTION
This PR updates our CI axes to build the `22.10` images.