### PR TITLE
Enable Arrow S3 support for libcudf.

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -178,7 +178,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -178,7 +178,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -176,7 +176,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -179,7 +179,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -179,7 +179,7 @@ RUN cd ${RAPIDS_DIR}/raft && \
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
 RUN cd ${RAPIDS_DIR}/cusignal && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -112,7 +112,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   python setup.py install
 
   {% elif lib.name == "cudf" %}
-  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests
+  ./build.sh --allgpuarch libcudf cudf dask_cudf libcudf_kafka cudf_kafka tests --cmake-args=\"-DCUDF_ENABLE_ARROW_S3=ON\"
 
   {% elif lib.name == "cuspatial" %}
   export CUSPATIAL_HOME="$PWD" && \


### PR DESCRIPTION
⚠️ This PR should be merged to `branch-22.10` once that branch exists.

This enables (retains support for) Arrow S3 in Docker builds of libcudf. PR https://github.com/rapidsai/cudf/pull/11470 changed the default behavior, turning the feature off.

See https://github.com/rapidsai/cudf/pull/11470#pullrequestreview-1063942110 / cc: @ajschmidt8