### PR TITLE
Revert mistune upgrade due to incompatibility

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -47,8 +47,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -60,8 +60,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -48,8 +48,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-base.amd64.Dockerfile
@@ -47,8 +47,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-base.arm64.Dockerfile
@@ -47,8 +47,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -60,8 +60,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -58,8 +58,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
@@ -48,8 +48,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
@@ -48,8 +48,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN yum -y upgrade \
     && yum clean all
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.amd64.Dockerfile
@@ -49,8 +49,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-base.arm64.Dockerfile
@@ -49,8 +49,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -65,8 +65,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -63,8 +63,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -50,8 +50,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -50,8 +50,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.amd64.Dockerfile
@@ -49,8 +49,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-base.arm64.Dockerfile
@@ -49,8 +49,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -65,8 +65,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -63,8 +63,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -50,8 +50,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -50,8 +50,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*

--- a/templates/rapidsai-core/partials/patch.dockerfile.j2
+++ b/templates/rapidsai-core/partials/patch.dockerfile.j2
@@ -6,9 +6,6 @@ RUN source activate rapids \
     && npm i -g npm@">=7.0" \
     && npm i -g codecov@">=3.7.1"
 
-{# Patch for CVE-2022-34749 https://github.com/advisories/GHSA-fw3v-x4f2-v673 #}
-RUN gpuci_mamba_retry install -y -n rapids "mistune>=2.0.3"
-
 {% if ( "rocky" in os or "centos" in os ) %}
 RUN yum -y upgrade \
     && yum clean all


### PR DESCRIPTION
`nbconvert-core` restricts `mistune` to `<2`, so this attempt at upgrading `mistune` fails.

See [build log](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-core-base-runtime/1067/BUILD_IMAGE=rapidsai%2Frapidsai-core,CUDA_VER=11.5,FROM_IMAGE=gpuci%2Frapidsai,IMAGE_TYPE=base,LINUX_VER=ubuntu18.04,PYTHON_VER=3.8,RAPIDS_VER=22.08/console)