### PR TITLE
Update `raft` build command

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -176,7 +176,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -176,7 +176,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -174,7 +174,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -178,7 +178,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -180,7 +180,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -178,7 +178,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -141,7 +141,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh --allgpuarch libcuml cuml prims
 
   {% elif lib.name == "raft"%}
-  ./build.sh --allgpuarch --compile-libs --install libraft pyraft pylibraft
+  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
 
   {% elif lib.name == "dask-cuda"%}
   python setup.py install


### PR DESCRIPTION
Since https://github.com/rapidsai/raft/pull/801 was merged, we need to update our build commands accordingly for `raft`.