### PR TITLE
update raft build cmd

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -179,7 +179,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -179,7 +179,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -177,7 +177,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -183,7 +183,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -183,7 +183,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -181,7 +181,7 @@ RUN cd ${RAPIDS_DIR}/benchmark && \
 
 RUN cd ${RAPIDS_DIR}/raft && \
   source activate rapids && \
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
 RUN cd ${RAPIDS_DIR}/cudf && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -141,7 +141,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   ./build.sh --allgpuarch libcuml cuml prims
 
   {% elif lib.name == "raft"%}
-  ./build.sh --allgpuarch --compile-libs --install libraft raft-dask pylibraft
+  ./build.sh --allgpuarch --compile-libs libraft raft-dask pylibraft
 
   {% elif lib.name == "dask-cuda"%}
   python setup.py install


### PR DESCRIPTION
The `--install` flag removed [here](https://github.com/rapidsai/raft/pull/1026/files) causes the `rapidsai/rapidsai-core-dev-nightly` image build to fail. 