### PR TITLE
[HOTFIX] Pin `openssl` version

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -74,8 +74,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -56,8 +56,9 @@ RUN yum -y upgrade \
     && yum clean all
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -74,8 +74,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -72,8 +72,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
@@ -56,8 +56,9 @@ RUN yum -y upgrade \
     && yum clean all
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
@@ -56,8 +56,9 @@ RUN yum -y upgrade \
     && yum clean all
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -79,8 +79,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -77,8 +77,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -79,8 +79,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -77,8 +77,9 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -1,8 +1,9 @@
 {# This partial is used to install notebooks and their deps into 'runtime' and 'devel' images #}
 
 {# Install the rapids-notebook-env meta-pkg #}
+ARG OPENSSL_VERSION=1.1.1
 RUN gpuci_mamba_retry install -y -n rapids \
-        "rapids-notebook-env=${RAPIDS_VER}*" \
+        "rapids-notebook-env=${RAPIDS_VER}*" "openssl=${OPENSSL_VERSION}" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
 


### PR DESCRIPTION
Without this `openssl` pin, our `openssl` version gets upgraded to version `3.0.7` from version `1.1.1`, which seems to cause CMake build issues for our `devel` containers.

This PR pins `openssl` to `1.1.1` to prevent these build issues.