### PR TITLE
fix: freeze installed

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -74,7 +74,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -82,7 +82,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -56,7 +56,7 @@ RUN yum -y upgrade \
     && yum clean all
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -64,7 +64,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -74,7 +74,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -82,7 +82,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -72,7 +72,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -80,7 +80,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
@@ -56,7 +56,7 @@ RUN yum -y upgrade \
     && yum clean all
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -64,7 +64,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
@@ -56,7 +56,7 @@ RUN yum -y upgrade \
     && yum clean all
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -64,7 +64,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -79,7 +79,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -87,7 +87,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -77,7 +77,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -85,7 +85,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.amd64.Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -66,7 +66,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-runtime.arm64.Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -66,7 +66,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -79,7 +79,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -87,7 +87,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -77,7 +77,7 @@ RUN source activate rapids \
   && conda config --show-sources \
   && conda list --show-channel-urls
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -85,7 +85,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.amd64.Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -66,7 +66,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-runtime.arm64.Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -66,7 +66,7 @@ RUN gpuci_mamba_retry install -y -n rapids \
 ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 RUN cd ${RAPIDS_DIR} \
   && source activate rapids \

--- a/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
+++ b/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2
@@ -1,7 +1,7 @@
 {# This partial is used to install notebooks and their deps into 'runtime' and 'devel' images #}
 
 {# Install the rapids-notebook-env meta-pkg #}
-RUN gpuci_mamba_retry install -y -n rapids \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
         "rapids-notebook-env=${RAPIDS_VER}*" \
     && gpuci_conda_retry remove -y -n rapids --force-remove \
         "rapids-notebook-env=${RAPIDS_VER}*"
@@ -11,8 +11,7 @@ ENV DASK_LABEXTENSION__FACTORY__MODULE="dask_cuda"
 ENV DASK_LABEXTENSION__FACTORY__CLASS="LocalCUDACluster"
 
 {# Install jupyter lab stuff #}
-{# TODO: Remove pyarrow pin when RAPIDS upgrades to a new pyarrow version #}
-RUN gpuci_mamba_retry install -y -n rapids jupyterlab-nvdashboard "pyarrow=9.0.0"
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed jupyterlab-nvdashboard
 
 {# Install notebooks repo #}
 RUN cd ${RAPIDS_DIR} \


### PR DESCRIPTION
This work around is implemented to stop `pyarrow` from upgrading to version 10 as this creates a conflict against the required RAPIDS preference of version 9.