### PR TITLE
Adds additional targets to cugraph build 

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -206,7 +206,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -206,7 +206,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -204,7 +204,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.amd64.Dockerfile
@@ -209,7 +209,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.arm64.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.amd64.Dockerfile
@@ -209,7 +209,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_ubuntu20.04-devel.arm64.Dockerfile
@@ -207,7 +207,7 @@ RUN cd ${RAPIDS_DIR}/cuml && \
 
 RUN cd ${RAPIDS_DIR}/cugraph && \
   source activate rapids && \
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
 RUN cd ${RAPIDS_DIR}/xgboost && \
   source activate rapids && \

--- a/templates/rapidsai-core/Devel.dockerfile.j2
+++ b/templates/rapidsai-core/Devel.dockerfile.j2
@@ -135,7 +135,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   cd ../python-package && python setup.py install;
 
   {% elif lib.name == "cugraph" %}
-  ./build.sh --allgpuarch cugraph libcugraph pylibcugraph
+  ./build.sh --allgpuarch libcugraph pylibcugraph cugraph cugraph-service cugraph-dgl cugraph-pyg
 
   {% elif lib.name == "cuml" %}
   ./build.sh --allgpuarch libcuml cuml prims


### PR DESCRIPTION
Adds additional targets to the `cugraph` build to include newer components that are expected to be built by the `docs` build and cugraph devs using these images.

This depends on https://github.com/rapidsai/integration/pull/584
