### PR TITLE
Reduce devel image matrix

### DIFF
--- a/ci/axis/rapidsai-clx-devel.yaml
+++ b/ci/axis/rapidsai-clx-devel.yaml
@@ -15,13 +15,9 @@ CUDA_VER:
   - 11.5
 
 LINUX_VER:
-  - ubuntu18.04
   - ubuntu20.04
-  - centos7
-  - rockylinux8
 
 PYTHON_VER:
-  - 3.8
   - 3.9
 
 exclude:

--- a/ci/axis/rapidsai-core-devel-arm64.yaml
+++ b/ci/axis/rapidsai-core-devel-arm64.yaml
@@ -15,12 +15,9 @@ CUDA_VER:
   - 11.5
 
 LINUX_VER:
-  - ubuntu18.04
   - ubuntu20.04
-  - rockylinux8
 
 PYTHON_VER:
-  - 3.8
   - 3.9
 
 exclude:

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -15,13 +15,9 @@ CUDA_VER:
   - 11.5
 
 LINUX_VER:
-  - ubuntu18.04
   - ubuntu20.04
-  - centos7
-  - rockylinux8
 
 PYTHON_VER:
-  - 3.8
   - 3.9
 
 exclude:

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -18,13 +18,9 @@ CUDA_VER:
   - 11.5
 
 LINUX_VER:
-  - ubuntu18.04
   - ubuntu20.04
-  - centos7
-  - rockylinux8
 
 PYTHON_VER:
-  - 3.8
   - 3.9
 
 exclude:


### PR DESCRIPTION
Reduces the matrix of devel containers to a single combination of `ubuntu20.04`, `cuda11.5`, and `python3.9`.