### PR TITLE
Revert "Install `xargs` for rockylinux"

### DIFF
--- a/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-base.amd64.Dockerfile
@@ -30,7 +30,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-devel.amd64.Dockerfile
@@ -33,7 +33,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_centos7-runtime.amd64.Dockerfile
@@ -31,7 +31,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-base.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-base.amd64.Dockerfile
@@ -30,7 +30,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-base.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-base.arm64.Dockerfile
@@ -30,7 +30,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.amd64.Dockerfile
@@ -33,7 +33,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-devel.arm64.Dockerfile
@@ -33,7 +33,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.amd64.Dockerfile
@@ -31,7 +31,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
+++ b/generated-dockerfiles/rapidsai-core_rockylinux8-runtime.arm64.Dockerfile
@@ -31,7 +31,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 
 

--- a/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
+++ b/templates/rapidsai-core/partials/os_pkgs.dockerfile.j2
@@ -3,7 +3,6 @@ RUN yum install -y \
       openssh-clients \
       openmpi-devel \
       libnsl \
-      findutils \
       && yum clean all
 {% endif %}
 


### PR DESCRIPTION
Reverts rapidsai/docker#510

Since we don't build `devel` containers for `rockylinux` anymore, we can revert this change.