### PR TITLE
Fix broken GHA workflow

### DIFF
--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Check diffs
         run: |
           set -x
-          ls -al
           pwd
           git diff
           git diff --exit-code --quiet

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -9,7 +9,6 @@ jobs:
   up-to-date:
     name: up-to-date
     runs-on: ubuntu-latest
-    container: python:3.8
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Check diffs
         run: |
           set -x
+          ls -al
           pwd
           git diff
           git diff --exit-code --quiet

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -31,7 +31,5 @@ jobs:
           BASE_BRANCH_NAME: ${{ github.base_ref }}
       - name: Check diffs
         run: |
-          set -x
-          pwd
           git diff
           git diff --exit-code --quiet

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -32,5 +32,7 @@ jobs:
           BASE_BRANCH_NAME: ${{ github.base_ref }}
       - name: Check diffs
         run: |
+          set -x
+          pwd
           git diff
           git diff --exit-code --quiet

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Check diffs
         run: |
           set -x
+          git --version
           ls -al
           pwd
           git diff

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Check diffs
         run: |
           set -x
-          git --version
           ls -al
           pwd
           git diff


### PR DESCRIPTION
This PR updates the `generated-files` workflow to remove the `python` container, which was causing an issue due to using an outdated version of `git`.