### PR TITLE
Add ops-bot config

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,4 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+copy_prs: true


### PR DESCRIPTION
Adds the `ops-bot.yaml` config enabling `copy_prs`. This is required support GitHub Actions CI required by #539.

After this is merged, I will cut `branch-23.06`.