### PR TITLE
Refactor dask-sql updating workflow to use shortened version for `DASK_SQL_VER`

### DIFF
--- a/.github/workflows/update-dask-sql.yml
+++ b/.github/workflows/update-dask-sql.yml
@@ -16,12 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get old dask-sql version
-        id: old_version
-        uses: the-coding-turtle/ga-yaml-parser@v0.1.1
+      - name: Get current dask-sql version
+        id: current_version
+        uses: the-coding-turtle/ga-yaml-parser@v0.1.2
         with:
           file: settings.yaml
-          key: STABLE_DASK_SQL_VERSION
 
       - name: Get new dask-sql version
         id: new_version
@@ -31,12 +30,25 @@ jobs:
           package: "dask-sql"
           version_system: "SemVer"
 
-      - name: Find and replace dask-sql version
-        uses: jacobtomlinson/gha-find-replace@2.0.0
+      - name: Get current/new versions without patch
+        env:
+          FULL_VER: ${{ steps.current_version.outputs.STABLE_DASK_SQL_VERSION }}
+          FULL_NEW_VER: ${{ steps.new_version.outputs.version }}
+        run: |
+          echo SHORT_VER=${FULL_VER::-2} >> $GITHUB_ENV
+          echo SHORT_NEW_VER=${FULL_NEW_VER::-2} >> $GITHUB_ENV
+
+      - name: Find and replace full dask-sql version
+        uses: jacobtomlinson/gha-find-replace@3
         with:
-          find: ${{ steps.old_version.outputs.result }}
+          find: ${{ steps.current_version.outputs.STABLE_DASK_SQL_VERSION }}
           replace: ${{ steps.new_version.outputs.version }}
-          regex: false
+
+      - name: Find and replace short dask-sql version
+        uses: jacobtomlinson/gha-find-replace@3
+        with:
+          find: ${{ env.SHORT_VER }}
+          replace: ${{ env.SHORT_NEW_VER }}
 
       - name: Create pull request with changes
         uses: peter-evans/create-pull-request@v3

--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -13,7 +13,7 @@ RAPIDS_VER:
   - '23.04'
 
 DASK_SQL_VER:
-  - '2023.2.0'
+  - '2023.2'
 
 CUDA_VER:
   - 11.8

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -12,7 +12,7 @@ RAPIDS_VER:
   - '23.04'
 
 DASK_SQL_VER:
-  - '2023.2.0'
+  - '2023.2'
 
 CUDA_VER:
   - 11.8


### PR DESCRIPTION
As discussed a while ago with @ajschmidt8, we are erroneously installing the stable version of Dask-SQL in our nightly containers.

This PR makes some modifications to the version specification and workflow updating these specifications so that we will now properly install the nightly version in these containers as expected.