### PR TITLE
Use full version for dask-sql

### DIFF
--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -12,7 +12,7 @@ RAPIDS_VER:
   - '23.04'
 
 DASK_SQL_VER:
-  - '2023.2'
+  - '2023.2.0'
 
 CUDA_VER:
   - 11.8

--- a/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_centos7-devel.amd64.Dockerfile
@@ -23,7 +23,7 @@ ENV DASK_SQL_DIR=/dask-sql
 RUN gpuci_mamba_retry install -y -n rapids \
       "setuptools-rust" \
       && gpuci_mamba_retry install -y -n rapids \
-      --only-deps dask-sql=${DASK_SQL_VER} \
+      --only-deps "dask-sql=${DASK_SQL_VER%.*}" \
       && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- --profile=minimal -y
 

--- a/generated-dockerfiles/rapidsai_rockylinux8-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_rockylinux8-devel.amd64.Dockerfile
@@ -23,7 +23,7 @@ ENV DASK_SQL_DIR=/dask-sql
 RUN gpuci_mamba_retry install -y -n rapids \
       "setuptools-rust" \
       && gpuci_mamba_retry install -y -n rapids \
-      --only-deps dask-sql=${DASK_SQL_VER} \
+      --only-deps "dask-sql=${DASK_SQL_VER%.*}" \
       && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- --profile=minimal -y
 

--- a/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu20.04-devel.amd64.Dockerfile
@@ -23,7 +23,7 @@ ENV DASK_SQL_DIR=/dask-sql
 RUN gpuci_mamba_retry install -y -n rapids \
       "setuptools-rust" \
       && gpuci_mamba_retry install -y -n rapids \
-      --only-deps dask-sql=${DASK_SQL_VER} \
+      --only-deps "dask-sql=${DASK_SQL_VER%.*}" \
       && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- --profile=minimal -y
 

--- a/generated-dockerfiles/rapidsai_ubuntu22.04-devel.amd64.Dockerfile
+++ b/generated-dockerfiles/rapidsai_ubuntu22.04-devel.amd64.Dockerfile
@@ -23,7 +23,7 @@ ENV DASK_SQL_DIR=/dask-sql
 RUN gpuci_mamba_retry install -y -n rapids \
       "setuptools-rust" \
       && gpuci_mamba_retry install -y -n rapids \
-      --only-deps dask-sql=${DASK_SQL_VER} \
+      --only-deps "dask-sql=${DASK_SQL_VER%.*}" \
       && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- --profile=minimal -y
 

--- a/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
+++ b/templates/rapidsai/partials/clone_and_build_dask-sql.dockerfile.j2
@@ -4,7 +4,7 @@
 RUN gpuci_mamba_retry install -y -n rapids \
       "setuptools-rust" \
       && gpuci_mamba_retry install -y -n rapids \
-      --only-deps dask-sql=${DASK_SQL_VER} \
+      --only-deps "dask-sql=${DASK_SQL_VER%.*}" \
       && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- --profile=minimal -y
 


### PR DESCRIPTION
Follow up from #541 

Since the devel build uses the `DASK_SQL_VER` to pick which branch or tag to clone, it must use the full version to successfully clone https://github.com/dask-contrib/dask-sql/tree/2023.2.0

Also strips the patch version from `DASK_SQL_VER` when installing the dependencies via `mamba`.

See a recent failed build [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel/797/BUILD_IMAGE=rapidsai%2Frapidsai-dev-nightly,CUDA_VER=11.8,DASK_SQL_VER=2023.2,FROM_IMAGE=rapidsai%2Frapidsai-core-dev-nightly,IMAGE_TYPE=devel,LINUX_VER=ubuntu22.04,PYTHON_VER=3.10,RAPIDS_VER=23.04/console)