### PR TITLE
Drop ubuntu20.04 from arm64 images

### DIFF
--- a/ci/axis/rapidsai-core-base-runtime-arm64.yaml
+++ b/ci/axis/rapidsai-core-base-runtime-arm64.yaml
@@ -19,7 +19,6 @@ CUDA_VER:
   - 11.2
 
 LINUX_VER:
-  - ubuntu20.04
   - ubuntu22.04
   - rockylinux8
 


### PR DESCRIPTION
Due a bug in `glibc` (https://bugzilla.redhat.com/show_bug.cgi?id=1722181) which affects `2.31`, we can't publish an `arm64` `ubuntu20.04` image since it ships with `glibc` `2.31`. `x86_64` images are not affected.

This is the error when trying to work with `cuml` or `cugraph`: `ImportError: /opt/conda/envs/rapids/lib/python3.9/site-packages/cuml/internals/../../../.././libgomp.so.1: cannot allocate memory in static TLS block`

`glibc` versions:
- `ubuntu20.04` - 2.31
- `ubuntu22.04` - 2.35
- `rockylinux8` - 2.28
