### PR TITLE
Enable 23.08 nightly builds

### DIFF
--- a/ci/axis/rapidsai-base-runtime.yaml
+++ b/ci/axis/rapidsai-base-runtime.yaml
@@ -33,7 +33,7 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '23.08'
-    BUILD_IMAGE: rapidsai/rapidsai-nightly
+    BUILD_IMAGE: rapidsai/rapidsai
 
   - CUDA_VER: 11.2
     LINUX_VER: ubuntu22.04

--- a/ci/axis/rapidsai-core-base-runtime-arm64.yaml
+++ b/ci/axis/rapidsai-core-base-runtime-arm64.yaml
@@ -28,7 +28,7 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '23.08'
-    BUILD_IMAGE: rapidsai/rapidsai-core-nightly-arm64
+    BUILD_IMAGE: rapidsai/rapidsai-core-arm64
 
   - CUDA_VER: 11.2
     LINUX_VER: ubuntu22.04

--- a/ci/axis/rapidsai-core-base-runtime.yaml
+++ b/ci/axis/rapidsai-core-base-runtime.yaml
@@ -30,7 +30,7 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '23.08'
-    BUILD_IMAGE: rapidsai/rapidsai-core-nightly
+    BUILD_IMAGE: rapidsai/rapidsai-core
   
   - CUDA_VER: 11.2
     LINUX_VER: ubuntu22.04

--- a/ci/axis/rapidsai-core-devel-arm64.yaml
+++ b/ci/axis/rapidsai-core-devel-arm64.yaml
@@ -22,4 +22,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '23.08'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly-arm64
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev-arm64

--- a/ci/axis/rapidsai-core-devel.yaml
+++ b/ci/axis/rapidsai-core-devel.yaml
@@ -22,4 +22,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '23.08'
-    BUILD_IMAGE: rapidsai/rapidsai-core-dev-nightly
+    BUILD_IMAGE: rapidsai/rapidsai-core-dev

--- a/ci/axis/rapidsai-devel.yaml
+++ b/ci/axis/rapidsai-devel.yaml
@@ -25,4 +25,4 @@ PYTHON_VER:
 
 exclude:
   - RAPIDS_VER: '23.08'
-    BUILD_IMAGE: rapidsai/rapidsai-dev-nightly
+    BUILD_IMAGE: rapidsai/rapidsai-dev


### PR DESCRIPTION
I disabled the Jenkins jobs to build `branch-23.08` and will re-enable after this PR is merged to prevent `23.08` images from being pushed to stable docker repos.

Ref #553 