### PR TITLE
Publish multiarch images w/o tests

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -147,7 +147,7 @@ jobs:
         ${{ matrix.ARCH }}"
   build-multiarch-manifest:
     if: inputs.build_type == 'branch'
-    needs: [build, test, compute-matrix]
+    needs: [build, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since nightly tests are not yet enabled, the `build-multiarch-manifest` job should run without the `test` job. This will ensure nightly images are pushed to Docker Hub.

Skipping CI since this job does not run on PRs.