### PR TITLE
Remove repos that should not be notebook tested

### DIFF
--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-NOTEBOOK_REPOS=(cudf cuml cugraph cuxfilter cuspatial cusignal xgboost-conda)
+NOTEBOOK_REPOS=(cudf cuml cugraph cuspatial)
 
 mkdir -p /notebooks /dependencies
 for REPO in "${NOTEBOOK_REPOS[@]}"; do


### PR DESCRIPTION
Internal discussions resulted that just `cudf`, `cuml`, `cugraph`, & `cuspatial` notebooks should be tested.

We might exclude more notebooks and will iterate on this PR.
