### PR TITLE
Add input to enable testing

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -6,6 +6,10 @@ on:
       build_type:
         required: true
         type: string
+      run_tests:
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -123,8 +127,7 @@ jobs:
         py${{ matrix.PYTHON_VER }}"
   test:
     needs: [build, compute-matrix]
-    # TODO: nightly tests
-    if: inputs.build_type == 'pull-request'
+    if: inputs.run_tests
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.TEST_MATRIX) }}
       fail-fast: false

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -150,7 +150,7 @@ jobs:
         ${{ matrix.ARCH }}"
   build-multiarch-manifest:
     if: inputs.build_type == 'branch'
-    needs: [build, test, compute-matrix]
+    needs: [build, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,4 +14,5 @@ jobs:
     uses: ./.github/workflows/build-test-publish-images.yml
     with:
       build_type: pull-request
+      run_tests: true
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:
+    inputs:
+      run_tests:
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref }}"
@@ -17,6 +22,7 @@ jobs:
     uses: ./.github/workflows/build-test-publish-images.yml
     with:
       build_type: branch
+      run_tests: ${{ inputs.run_tests || false }}
     secrets: inherit
   readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install awscli
         if: '!cancelled()'
         run: rapids-mamba-retry install -n base awscli
-      - uses: aws-actions/configure-aws-credentials@v1-node16
+      - uses: aws-actions/configure-aws-credentials@v2
         if: '!cancelled()'
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -2,7 +2,7 @@ pull-request:
   - { CUDA_VER: '11.2.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
   - { CUDA_VER: '12.0.1', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '11.8.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
-nightly:
+branch:
   - { CUDA_VER: '11.2.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
   - { CUDA_VER: '11.2.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '11.8.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }


### PR DESCRIPTION
Refactoring how tests are triggered to use an input. This will allow a calling workflow in `rapidsai/actions` to execute the notebook tests on a nightly basis.
