### PR TITLE
Updates to the `update-dask-sql.yml` workflow

### DIFF
--- a/.github/workflows/update-dask-sql.yml
+++ b/.github/workflows/update-dask-sql.yml
@@ -11,16 +11,18 @@ on:
 jobs:
   update-dask-sql:
     runs-on: ubuntu-latest
+    container:
+      image: rapidsai/ci:latest
     if: github.repository == 'rapidsai/docker'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get current dask-sql version
         id: current_version
-        uses: the-coding-turtle/ga-yaml-parser@v0.1.2
-        with:
-          file: matrix.yaml
+        run: |
+          DASK_SQL_VER="$(yq -r '.DASK_SQL_VER.[0]' matrix.yaml)"
+          echo "DASK_SQL_VER=${DASK_SQL_VER}" | tee -a ${GITHUB_OUTPUT}
 
       - name: Get new dask-sql version
         id: new_version
@@ -35,8 +37,8 @@ jobs:
           FULL_VER: ${{ steps.current_version.outputs.DASK_SQL_VER }}
           FULL_NEW_VER: ${{ steps.new_version.outputs.version }}
         run: |
-          echo SHORT_VER=${FULL_VER::-2} >> $GITHUB_ENV
-          echo SHORT_NEW_VER=${FULL_NEW_VER::-2} >> $GITHUB_ENV
+          echo SHORT_VER=${FULL_VER%.*} >> $GITHUB_ENV
+          echo SHORT_NEW_VER=${FULL_NEW_VER%.*} >> $GITHUB_ENV
 
       - name: Find and replace full dask-sql version
         uses: jacobtomlinson/gha-find-replace@v3
@@ -54,8 +56,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update `STABLE_DASK_SQL_VERSION` to `${{ steps.new_version.outputs.version }}`
-          title: Update `STABLE_DASK_SQL_VERSION` to `${{ steps.new_version.outputs.version }}`
+          commit-message: Update `DASK_SQL_VERSION` to `${{ steps.new_version.outputs.version }}`
+          title: Update `DASK_SQL_VERSION` to `${{ steps.new_version.outputs.version }}`
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-dask-sql"
           body: |


### PR DESCRIPTION
This PR updated the `update-dask-sql.yml` workflow. This should resolve the previous failures such as https://github.com/rapidsai/docker/actions/runs/5756838849/job/15606942103

Changes:
- `the-coding-turtle/ga-yaml-parser` uses deprecated `::set-output`, so switching to use `yq` & `$GITHUB_OUTPUT` instead. This requires using the `rapidai/ci:latest` container so `yq` is available.
- Minor clean up for versions & PR text
- Updates the checkout action version
