### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -200,7 +200,7 @@ jobs:
           docker manifest push ${notebooks_tag}
   delete-temp-images:
     if: always()
-    needs: [compute-matrix, build-multiarch-manifest]
+    needs: [compute-matrix, build, test, build-multiarch-manifest]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.