### PR TITLE
Ensure curl is installed before `gha-tools`

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -65,14 +65,15 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Install required tools
+        run: |
+          mamba install -n base --freeze-installed \
+            curl \
+            git
       - name: Install gha-tools
         run: |
           mkdir -p "$GHA_TOOLS_DIR"
           curl -s -L 'https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz' | tar -xz -C "$GHA_TOOLS_DIR"
-      - name: Install git
-        run: |
-          PATH="$PATH:$GHA_TOOLS_DIR"
-          rapids-mamba-retry install -n base --freeze-installed git
       - name: Checkout code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Not 100% sure why, but [starting recently](https://github.com/rapidsai/docker/actions/runs/5923767292/job/16060805130#step:4:8), `curl` is no longer available in the `notebooks` image during tests.

This PR ensures `curl` & `git` are installed before installing `gha-tools` and running tests. Using `--freeze-installed` ensures the tests run on the same environment that is published with the exception of `curl`, `git`, and `perl` (dependency of `git`) being present, but those packages should not impact the tests.
