### PR TITLE
[NO MRG] Test `cuda-version` in `nvidia/label/tst`

### DIFF
--- a/context/condarc
+++ b/context/condarc
@@ -1,7 +1,7 @@
 auto_update_conda: False
 channels:
-  - rapidsai-nightly
-  - dask/label/dev
+  - rapidsai
+  - dask
   - pytorch
   - conda-forge
   - nvidia

--- a/context/condarc
+++ b/context/condarc
@@ -5,3 +5,4 @@ channels:
   - pytorch
   - conda-forge
   - nvidia
+  - nvidia/label/tst


### PR DESCRIPTION
Just try adding the `nvidia/label/tst` channel package, which currently includes `cuda-version` to see how that affects RAPIDS installs