### PR TITLE
Add NotebookApp.base_url to jupyter-lab command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,4 +84,4 @@ EXPOSE 8888
 
 ENTRYPOINT ["/home/rapids/entrypoint.sh"]
 
-CMD ["jupyter-lab", "--notebook-dir=/home/rapids/notebooks", "--ip=0.0.0.0", "--no-browser", "--NotebookApp.token=''", "--NotebookApp.allow_origin='*'"]
+CMD [ "sh", "-c", "jupyter-lab --notebook-dir=/home/rapids/notebooks --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=\"${NB_PREFIX:-/}\"" ]


### PR DESCRIPTION
Closes #587

Adds `--NotebookApp.base_url="${NB_PREFIX:-/}"` to the `jupyter-lab` `CMD` in the `notebooks` image. Since this relies on an environment variable, the `CMD` has to be switched to invoke a shell. See: https://docs.docker.com/engine/reference/builder/#cmd

I think this was missed during the overhaul.

xref: #426
