### PR TITLE
Backporting #590

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -34,7 +34,7 @@ jobs:
   compute-matrix:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci:latest
+      image: rapidsai/ci-conda:latest
     outputs:
       BASE_IMAGE_REPO: ${{ steps.compute-image-repo.outputs.BASE_IMAGE_REPO }}
       NOTEBOOKS_IMAGE_REPO: ${{ steps.compute-image-repo.outputs.NOTEBOOKS_IMAGE_REPO }}

--- a/.github/workflows/update-dask-sql.yml
+++ b/.github/workflows/update-dask-sql.yml
@@ -12,7 +12,7 @@ jobs:
   update-dask-sql:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci:latest
+      image: rapidsai/ci-conda:latest
     if: github.repository == 'rapidsai/docker'
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG RAPIDS_VER=23.08
 ARG DASK_SQL_VER=2023.8.0
 
 # Gather dependency information
-FROM rapidsai/ci:latest AS dependencies
+FROM rapidsai/ci-conda:latest AS dependencies
 ARG CUDA_VER
 ARG PYTHON_VER
 


### PR DESCRIPTION
We need to do a rebuild of `23.08` to fix CVE-2023-4863.

This requires using the new `rapidsai/ci-conda` images, so just backporting the commit that updated the images.
