### PR TITLE
Update mambaforge to miniforge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN /notebooks.sh
 
 
 # Base image
-FROM rapidsai/mambaforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} as base
+FROM rapidsai/miniforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} as base
 ARG CUDA_VER
 ARG PYTHON_VER
 

--- a/dockerhub-readme.md
+++ b/dockerhub-readme.md
@@ -27,7 +27,7 @@ RAPIDS Libraries included in the images:
 
 ### Image Types
 
-The RAPIDS images are based on [`nvidia/cuda`](https://hub.docker.com/r/nvidia/cuda) and [`rapidsai/mambaforge-cuda`](https://hub.docker.com/r/rapidsai/mambaforge-cuda). The RAPIDS images provide `amd64` & `arm64` architectures [where supported](https://docs.rapids.ai/install#system-req).
+The RAPIDS images are based on [`nvidia/cuda`](https://hub.docker.com/r/nvidia/cuda) and [`rapidsai/miniforge-cuda`](https://hub.docker.com/r/rapidsai/miniforge-cuda). The RAPIDS images provide `amd64` & `arm64` architectures [where supported](https://docs.rapids.ai/install#system-req).
 
 
 There are two types:


### PR DESCRIPTION
We're renaming our mambaforge images to miniforge as described in [this PR](https://github.com/rapidsai/mambaforge-cuda/pull/51). This PR updates the old references in this repository.