### PR TITLE
Add a pin to `dask-sql` during the notebok env update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,13 @@ ARG CUDA_VER
 ARG PYTHON_VER
 
 ARG RAPIDS_VER
+ARG DASK_SQL_VER
 
 ARG RAPIDS_BRANCH="branch-${RAPIDS_VER}"
 
 RUN pip install --upgrade conda-merge rapids-dependency-file-generator
 
+COPY condarc /condarc
 COPY notebooks.sh /notebooks.sh
 
 RUN /notebooks.sh

--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -3,6 +3,7 @@
 # Clones repos with notebooks & compiles notebook test dependencies
 # Requires environment variables:
 #    RAPIDS_BRANCH
+#    DASK_SQL_VER
 #    CUDA_VER
 #    PYTHON_VER
 
@@ -15,15 +16,18 @@ for REPO in "${NOTEBOOK_REPOS[@]}"; do
     echo "Cloning $REPO..."
     git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
     cp -rL "$REPO"/notebooks /notebooks/"$REPO"
-    if [ -f "$REPO/dependencies.yaml" ] && yq -e '.files.test_notebooks' "$REPO/dependencies.yaml" > /dev/null; then
+    if [ -f "$REPO/dependencies.yaml" ] && yq -e '.files.test_notebooks' "$REPO/dependencies.yaml" >/dev/null; then
         echo "Running dfg on $REPO"
         rapids-dependency-file-generator \
             --config "$REPO/dependencies.yaml" \
             --file_key test_notebooks \
             --matrix "cuda=${CUDA_VER%.*};arch=$(arch);py=${PYTHON_VER}" \
-            --output conda > "/dependencies/${REPO}_notebooks_tests_dependencies.yaml"; \
+            --output conda >"/dependencies/${REPO}_notebooks_tests_dependencies.yaml"
     fi
 done
 
 pushd "/dependencies"
-conda-merge ./*.yaml > /test_notebooks_dependencies.yaml
+conda-merge ./*.yaml |
+    yq ".dependencies += [\"dask-sql==${DASK_SQL_VER%.*}.*\"]" | # Ensure dask-sql dependency is not altered
+    yq '.channels = load("/condarc").channels' |                 # Use channels provided by CI, not repos
+    tee /test_notebooks_dependencies.yaml


### PR DESCRIPTION
This PR does two things:
1. Adds a pin for `dask-sql` to the test notebook dependencies environment file to prevent downgrading seen [here](https://github.com/rapidsai/docker/actions/runs/6417495353/job/17423393145#step:10:542)
2. Overwrites the channels in the test notebook dependencies environment file to prevent using nightlies during a release build
