### PR TITLE
use new shared-actions repo

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
       - name: Get RAPIDS GitHub Info
         id: get-rapids-github-info
-        uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.10
+        uses: rapidsai/shared-actions/rapids-github-info@main
       - name: Print environment
         run: |
           PATH="$PATH:$GHA_TOOLS_DIR"


### PR DESCRIPTION
Updates the reference to the shared `rapids-github-info` action to use the new `rapidsai/shared-actions` repository.