### PR TITLE
Enable AARCH64 raft-ann-bench images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -114,7 +114,6 @@ jobs:
             DASK_SQL_VER=${{ inputs.DASK_SQL_VER }}
           tags: ${{ inputs.NOTEBOOKS_TAG }}-${{ matrix.ARCH }}
       - name: Build RAFT ANN Benchmarks GPU image
-        if: (!(inputs.CUDA_VER == '11.8.0' && matrix.ARCH == 'arm64')) # no ARM CUDA 11.8 packages on rapidsai-nightly channel, enabling this in follow up PR
         uses: docker/build-push-action@v4
         with:
           context: context
@@ -129,7 +128,6 @@ jobs:
             RAPIDS_VER=${{ inputs.RAPIDS_VER }}
           tags: ${{ inputs.RAFT_ANN_BENCH_TAG }}-${{ matrix.ARCH }}
       - name: Build RAFT ANN Benchmarks GPU with datasets image
-        if: (!(inputs.CUDA_VER == '11.8.0' && matrix.ARCH == 'arm64')) # no ARM CUDA 11.8 packages on rapidsai-nightly channel, enabling this in follow up PR
         uses: docker/build-push-action@v4
         with:
           context: context


### PR DESCRIPTION
PR enables AARCH64 raft-ann-bench* images and fixes the multiarch GHA jobs. 