### PR TITLE
Add CUDA 12 arm64 to the matrix

### DIFF
--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -2,7 +2,6 @@ def compute_arch($x):
   ["amd64"] |
   if
     $x.LINUX_VER != "ubuntu20.04" # Dask-sql arm64 requires glibc >=2.32
-    and $x.CUDA_VER < "12.0" # arm64 packages not available for CUDA 12.0 yet
   then
     . + ["arm64"]
   else

--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -2,11 +2,13 @@
 
 pull-request:
   - { CUDA_VER: '11.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '11.8', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
 branch:
   - { CUDA_VER: '11.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
   - { CUDA_VER: '11.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '11.8', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
   - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }


### PR DESCRIPTION
Update `compute-matrix.jq` to allow for CUDA 12 arm64 builds.

Also modifies the test matrix for CUDA 12 arm64 based on https://github.com/rapidsai/shared-action-workflows/blob/branch-23.12/.github/workflows/conda-python-tests.yaml.
