### PR TITLE
Update `shared-action-workflows` references

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
       - name: Get RAPIDS GitHub Info
         id: get-rapids-github-info
-        uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.12
+        uses: rapidsai/shared-workflows/rapids-github-info@branch-23.12
       - name: Print environment
         run: |
           PATH="$PATH:$GHA_TOOLS_DIR"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -30,7 +30,7 @@ sed_runner "s/ARG RAPIDS_VER=.*/ARG RAPIDS_VER=${NEXT_SHORT_TAG}/g" Dockerfile
 
 # CI files
 for FILE in .github/workflows/*.yml; do
-  sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
 
 sed_runner "s/v[[:digit:]]\+\.[[:digit:]]\+/v${NEXT_SHORT_TAG}/g" dockerhub-readme.md


### PR DESCRIPTION
Update `shared-action-workflows` references to `shared-actions` following the work to rename the `rapidsai/shared-action-workflows` to `rapidsai/shared-workflows`.
