### PR TITLE
Install perl temporarily on RAFT benchmark containers

### DIFF
--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -16,6 +16,9 @@ RUN mkdir /data && chmod 777 /data \
     &&  ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \
     echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> /etc/bash.bashrc
 
+# we need perl temporarily for the remaining benchmark perl scripts
+RUN apt-get install perl -y
+
 # Install python before updating environment, otherwise Python 3.9 image
 # runs into a solver conflict with truststore 0.8.0. This avoids the environment installing
 # packages incompatible with python version needed before python itself is pinned to the correct version.

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -14,11 +14,13 @@ COPY condarc /opt/conda/.condarc
 
 # Create a data folder accessible by any user so mounted volumes under it can be accessible
 # when the user passes their uid to docker run with -u $(id -u)
-
 # Also add the conda_prefix config to the global bashrc file so that all users have it correctly configured.
 RUN mkdir /data && chmod 777 /data \
       && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \
       echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> /etc/bash.bashrc
+
+# we need perl temporarily for the remaining benchmark perl scripts
+RUN apt-get install perl -y
 
 # temporarily downgrade conda from 23.9.0 due to https://github.com/mamba-org/mamba/issues/2882
 # after the mamba update step


### PR DESCRIPTION
PR installs perl on RAFT benchmark containers since there are still some legacy scripts that need it. 