### PR TITLE
Add SHELL instruction for every stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ ARG PYTHON_VER
 ARG RAPIDS_VER
 ARG DASK_SQL_VER
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 RUN useradd -rm -d /home/rapids -s /bin/bash -g conda -u 1001 rapids
 
 USER rapids
@@ -62,6 +64,8 @@ CMD ["ipython"]
 
 # Notebooks image
 FROM base as notebooks
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 USER rapids
 

--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -49,6 +49,8 @@ ENTRYPOINT ["/bin/bash", "/data/scripts/run_benchmark.sh"]
 
 FROM bench-base as raft-ann-bench-cpu-datasets
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 COPY raft-ann-bench/get_datasets.sh /home/rapids/raftannbench/get_datasets.sh
 
 COPY raft-ann-bench/run_benchmark.sh /data/scripts/run_benchmark_preloaded_datasets.sh

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -52,6 +52,8 @@ ENTRYPOINT ["/bin/bash", "/data/scripts/run_benchmark.sh"]
 
 FROM raft-ann-bench as raft-ann-bench-datasets
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 COPY raft-ann-bench/get_datasets.sh /home/rapids/raftannbench/get_datasets.sh
 
 COPY raft-ann-bench/run_benchmarks_preloaded_datasets.sh /data/scripts/run_benchmarks_preloaded_datasets.sh


### PR DESCRIPTION
Replaces #616

Adds the `SHELL` instruction to every stage in each Dockerfile.

This ensures an error in any `RUN` will fail the build. Such as https://github.com/rapidsai/docker/actions/runs/7130639487/job/19419248901#step:9:235
