### PR TITLE
Drop CUDA 11.2 from Docker matrix.

### DIFF
--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -1,14 +1,11 @@
 # CUDA_VER is `<major>.<minor>` (e.g. `11.2`)
 
 pull-request:
-  - { CUDA_VER: '11.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
   - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
 branch:
-  - { CUDA_VER: '11.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
-  - { CUDA_VER: '11.2', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '11.8', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
   - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }

--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -1,4 +1,4 @@
-# CUDA_VER is `<major>.<minor>` (e.g. `11.2`)
+# CUDA_VER is `<major>.<minor>` (e.g. `12.0`)
 
 pull-request:
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.9', GPU: 'v100', DRIVER: 'earliest' }

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,5 +1,4 @@
 CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `11.2.2`)
-  - "11.2.2"
   - "11.8.0"
   - "12.0.1"
 PYTHON_VER:


### PR DESCRIPTION
As communicated in RSN 35, this removes CUDA 11.2 from the Docker support matrix.

https://docs.rapids.ai/notices/rsn0035/