### PR TITLE
Pin cuda-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ mamba install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "dask-sql=${DASK_SQL_VER%.*}.*" \
     "python=${PYTHON_VER}.*" \
+    # cuda-python pin required for CUDA 12. See https://github.com/conda-forge/cuda-python-feedstock/issues/66
     "cuda-python=${CUDA_VER%.*}.*" \
     "cuda-version=${CUDA_VER%.*}.*" \
     ipython

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,12 @@ WORKDIR /home/rapids
 
 COPY condarc /opt/conda/.condarc
 
+# cuda-python pin required for CUDA 12. See https://github.com/conda-forge/cuda-python-feedstock/issues/66
 RUN <<EOF
 mamba install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "dask-sql=${DASK_SQL_VER%.*}.*" \
     "python=${PYTHON_VER}.*" \
-    # cuda-python pin required for CUDA 12. See https://github.com/conda-forge/cuda-python-feedstock/issues/66
     "cuda-python=${CUDA_VER%.*}.*" \
     "cuda-version=${CUDA_VER%.*}.*" \
     ipython

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ mamba install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "dask-sql=${DASK_SQL_VER%.*}.*" \
     "python=${PYTHON_VER}.*" \
+    "cuda-python=${CUDA_VER%.*}.*" \
     "cuda-version=${CUDA_VER%.*}.*" \
     ipython
 conda clean -afy


### PR DESCRIPTION
Fixes attempted in https://github.com/rapidsai/integration/pull/695 & https://github.com/rapidsai/integration/pull/697 don't play well with CEC at large, but this repo can pin `cuda-python` more restrictively.

This PR pins `cuda-python` to the CUDA `major.minor.*` version.

See also https://github.com/conda-forge/cuda-python-feedstock/issues/66