### PR TITLE
Revert "Pin cuda-python (#624)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,11 @@ WORKDIR /home/rapids
 
 COPY condarc /opt/conda/.condarc
 
-# cuda-python pin required for CUDA 12. See https://github.com/conda-forge/cuda-python-feedstock/issues/66
 RUN <<EOF
 mamba install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "dask-sql=${DASK_SQL_VER%.*}.*" \
     "python=${PYTHON_VER}.*" \
-    "cuda-python=${CUDA_VER%.*}.*" \
     "cuda-version=${CUDA_VER%.*}.*" \
     ipython
 conda clean -afy


### PR DESCRIPTION
Now that `cuda-python` packaging has been fixed to enable CUDA Enhanced Compatibility in https://github.com/conda-forge/cuda-python-feedstock/pull/67, we can unpin `cuda-python` in our Docker builds. This reverts commit 7c808e762eb73de09900fe2d692d6b0c5e80d6f2.