### PR TITLE
Remove deprecated cusignal from package list

### DIFF
--- a/dockerhub-readme.md
+++ b/dockerhub-readme.md
@@ -18,7 +18,6 @@ RAPIDS Libraries included in the images:
 - `RMM`
 - `RAFT`
 - `cuSpatial`
-- `cuSignal`
 - `cuxfilter`
 - `cuCIM`
 - `xgboost`


### PR DESCRIPTION
`cusignal` is no longer included in the images.