### PR TITLE
Skip cuspatial notebook tests

### DIFF
--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -25,7 +25,11 @@ ignored_subdirectory_names = [
 ignored_filenames = ["-csv", "benchmark", "target", "performance"]
 ignored_notebooks = [
     'cusignal/api_guide/io_examples.ipynb', # 26gb data download
-    'cugraph/algorithms/layout/Force-Atlas2.ipynb' # marked as skipped
+
+    # following nbs are marked as skipped
+    'cugraph/algorithms/layout/Force-Atlas2.ipynb',
+    'cuspatial/binary_predicates.ipynb',
+    'cuspatial/cuproj_benchmark.ipynb'
 ]
 
 


### PR DESCRIPTION
PR updates `test_notebooks.py` to skip  `cuspatial` notebooks which aren't being run in ci