### PR TITLE
Add `renovate` schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:base"],
+  "schedule": ["before 4am on the first day of the month"]
 }


### PR DESCRIPTION
This PR adds a once-a-month schedule for `renovate` to avoid excessive PR noise.

See their noise-reduction guide here for additional details: https://docs.renovatebot.com/noise-reduction/