### PR TITLE
Add retry to mamba installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /home/rapids
 COPY condarc /opt/conda/.condarc
 
 RUN <<EOF
-mamba install -y -n base \
+MAMBA_NO_LOW_SPEED_LIMIT=1 mamba install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "dask-sql=${DASK_SQL_VER%.*}.*" \
     "python=${PYTHON_VER}.*" \
@@ -82,12 +82,12 @@ COPY --from=dependencies --chown=rapids /test_notebooks_dependencies.yaml test_n
 COPY --from=dependencies --chown=rapids /notebooks /home/rapids/notebooks
 
 RUN <<EOF
-mamba env update -n base -f test_notebooks_dependencies.yaml
+MAMBA_NO_LOW_SPEED_LIMIT=1 mamba env update -n base -f test_notebooks_dependencies.yaml
 conda clean -afy
 EOF
 
 RUN <<EOF
-mamba install -y -n base \
+MAMBA_NO_LOW_SPEED_LIMIT=1 mamba install -y -n base \
         "jupyterlab=3" \
         dask-labextension
 pip install jupyterlab-nvdashboard

--- a/context/condarc
+++ b/context/condarc
@@ -5,3 +5,4 @@ channels:
   - pytorch
   - conda-forge
   - nvidia
+remote_max_retries: 3

--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get install perl -y
 # runs into a solver conflict with truststore 0.8.0. This avoids the environment installing
 # packages incompatible with python version needed before python itself is pinned to the correct version.
 RUN <<EOF
-MAMBA_NO_LOW_SPEED_LIMIT=1
+export MAMBA_NO_LOW_SPEED_LIMIT=1
 mamba install -y -n base "python=${PYTHON_VER}"
 mamba update --all -y -n base
 mamba install -y -n base \

--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get install perl -y
 # runs into a solver conflict with truststore 0.8.0. This avoids the environment installing
 # packages incompatible with python version needed before python itself is pinned to the correct version.
 RUN <<EOF
+MAMBA_NO_LOW_SPEED_LIMIT=1
 mamba install -y -n base "python=${PYTHON_VER}"
 mamba update --all -y -n base
 mamba install -y -n base \

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get install perl -y
 # temporarily downgrade conda from 23.9.0 due to https://github.com/mamba-org/mamba/issues/2882
 # after the mamba update step
 RUN <<EOF
+MAMBA_NO_LOW_SPEED_LIMIT=1
 mamba update --all -y -n base
 mamba install -y -n base \
     "raft-ann-bench=${RAPIDS_VER}.*" \

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install perl -y
 # temporarily downgrade conda from 23.9.0 due to https://github.com/mamba-org/mamba/issues/2882
 # after the mamba update step
 RUN <<EOF
-MAMBA_NO_LOW_SPEED_LIMIT=1
+export MAMBA_NO_LOW_SPEED_LIMIT=1
 mamba update --all -y -n base
 mamba install -y -n base \
     "raft-ann-bench=${RAPIDS_VER}.*" \


### PR DESCRIPTION
The docker builds are pretty consistently encountering `Download error (28) Timeout was reached` errors. It almost always occurs on a large RAPIDS package but that makes sense since they take the longest to download. I was able to reproduce locally, so I don't think it's a problem with our runners. I'm going to reach out to Anaconda separately.

This PR sets `remote_max_retries` so that `mamba` will retry which should help with the issue.

This also sets `MAMBA_NO_LOW_SPEED_LIMIT=1` which prevents `mamba` from erroring out if a download is too slow. Originally, I wasn't sure abut using this, but GHA times out on its own, so it should be safe.

Examples of the errors:
- https://github.com/rapidsai/docker/actions/runs/8466203792/job/23194501903#step:9:651
- https://github.com/rapidsai/docker/actions/runs/8506470533/job/23296743943#step:9:668
- https://github.com/rapidsai/docker/actions/runs/8520794283/job/23345886575#step:9:219 (dask repodata file that's only ~268kb)
