### PR TITLE
Pin jupyterlab-nvdashboard to `0.9`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN <<EOF
 mamba install -y -n base \
         "jupyterlab=3" \
         dask-labextension
-pip install jupyterlab-nvdashboard
+pip install "jupyterlab-nvdashboard==0.9.*"
 conda clean -afy
 pip cache purge
 EOF


### PR DESCRIPTION
`jupyterlab-nvdashboard` is going to release `0.10.0` soon which requires `jupyterlab>=4`.

Since RAPIDS `24.04` is being released today/tomorrow, we don't want to update `jupyterlab` to 4, so this PR pins `jupyterlab-nvdashboard==0.9.*`.

For `24.06`, we can unpin this and also upgrade to `jupyterlab` 4.