### PR TITLE
Add cuvs to list of libraries

### DIFF
--- a/dockerhub-readme.md
+++ b/dockerhub-readme.md
@@ -15,6 +15,7 @@ RAPIDS Libraries included in the images:
 - `cuDF`
 - `cuML`
 - `cuGraph`
+- `cuVS`
 - `RMM`
 - `RAFT`
 - `cuSpatial`


### PR DESCRIPTION
The rapids metapackage was updated to include `cuvs` by https://github.com/rapidsai/integration/pull/708, so add it to the list in the readme.