### PR TITLE
resolve file_key deprecation warning from rapids-dependency-file-generator

### DIFF
--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -33,7 +33,7 @@ for REPO in "${NOTEBOOK_REPOS[@]}"; do
         echo "Running dfg on $REPO"
         rapids-dependency-file-generator \
             --config "$REPO/dependencies.yaml" \
-            --file_key test_notebooks \
+            --file-key test_notebooks \
             --matrix "cuda=${CUDA_VER%.*};arch=$(arch);py=${PYTHON_VER}" \
             --output conda >"/dependencies/${REPO}_notebooks_tests_dependencies.yaml"
     fi


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

Resolves this warning from `rapids-dependency-file-generator`.

> /opt/conda/lib/python3.9/site-packages/rapids_dependency_file_generator/cli.py:98: UserWarning: The use of --file_key is deprecated. Use -f or --file-key instead.