### PR TITLE
Migrate to jupyterlab 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,11 +94,10 @@ EOF
 
 RUN <<EOF
 mamba install -y -n base \
-        "jupyterlab=3" \
-        dask-labextension
-pip install "jupyterlab-nvdashboard==0.9.*"
+    "jupyterlab=4" \
+    dask-labextension \
+    jupyterlab-nvdashboard
 conda clean -afy
-pip cache purge
 EOF
 
 # Disable the JupyterLab announcements


### PR DESCRIPTION
Upgrading the `notebooks` image to use `jupyterlab`4. This allows for unpinning `jupyterlab-nvdashboard` as well.

Also switches installing `jupyterlab-nvdashboard` from `pip` to `conda` which seems to work now and would close https://github.com/rapidsai/jupyterlab-nvdashboard/issues/156.
