### PR TITLE
add pr-builder job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-builder:
+    needs:
+      - checks
+      - docker
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.08
   checks:
     runs-on: ubuntu-latest
     steps:
@@ -29,9 +35,3 @@ jobs:
       build_type: pull-request
       run_tests: true
     secrets: inherit
-  pr-builder:
-    needs:
-      - checks
-      - docker
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.08

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,3 +29,9 @@ jobs:
       build_type: pull-request
       run_tests: true
     secrets: inherit
+  pr-builder:
+    needs:
+      - checks
+      - docker
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.08


### PR DESCRIPTION
fixes #691

Proposes adding the `pr-builder` workflow, to ensure that all required checks have passed prior to merging (or auto-merging!) here.

This makes auto-merger in this repo behave the way it does across most other repos (https://docs.rapids.ai/resources/auto-merger/).

In exchange, it means all changes will now require a full CI run to be merged. That can take 1-2 hours ([list of recent runs](https://github.com/rapidsai/docker/actions/workflows/pr.yml?query=is%3Asuccess)).

## Manual actions before merging

* [ ] an admin needs to add branch protection(s) blocking merge if the `pr-builder` workflow does not succeed