### PR TITLE
Skip failing notebooks for 24.08

### DIFF
--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -33,6 +33,8 @@ ignored_notebooks = [
     'cuspatial/nyc_taxi_years_correlation.ipynb',
     # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
     'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
+    # context on skip forest inference: https://github.com/rapidsai/cuml/issues/6008
+    'cuml/forest_inference_demo.ipynb',
 ]
 
 

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -30,7 +30,9 @@ ignored_notebooks = [
     'cuspatial/cuproj_benchmark.ipynb',
     # context on these being skipped: https://github.com/rapidsai/cuspatial/pull/1407
     'cuspatial/cuspatial_api_examples.ipynb',
-    'cuspatial/nyc_taxi_years_correlation.ipynb'
+    'cuspatial/nyc_taxi_years_correlation.ipynb',
+    # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
+    'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
 ]
 
 

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -33,8 +33,6 @@ ignored_notebooks = [
     'cuspatial/nyc_taxi_years_correlation.ipynb',
     # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
     'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
-    # context on skip forest inference: https://github.com/rapidsai/cuml/issues/6008
-    'cuml/forest_inference_demo.ipynb',
 ]
 
 


### PR DESCRIPTION
Currently `branch-24.08` is [failing on GHA]( https://github.com/rapidsai/docker/actions/runs/10213535034/job/28292218308#step:9:208 ) because of cuSpatial's `ZipCodes_Stops_PiP_cuSpatial.ipynb`

These failures are already reported in these projects issues:
* https://github.com/rapidsai/cuspatial/issues/1426

To help get 24.08 containers out, skip these notebook in the tests here