### PR TITLE
enable jobs retry & multi-arch builds of succeeding docker image builds

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -228,7 +228,7 @@ jobs:
         cuda${{ matrix.CUDA_VER }}-\
         py${{ matrix.PYTHON_VER }}"
   delete-temp-images:
-    if: ${{ !cancelled() && needs.build-multiarch-manifest.result == 'success' }}
+    if: ${{ !cancelled() && needs.test.result == 'success' }}
     needs: [compute-matrix, build-multiarch-manifest, test]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -226,94 +226,35 @@ jobs:
           RAFT_ANN_BENCH_CPU_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_TAG_PREFIX }}
           GPUCIBOT_DOCKERHUB_USER: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+          ARCHES: ${{ toJSON(matrix.ARCHES) }}
         run: ci/create-multiarch-manifest.sh
 
   delete-temp-images:
-    needs: [compute-matrix, build, test, build-multiarch-manifest]
+    if: '!cancelled()'
+    needs: [compute-matrix, build-multiarch-manifest]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Remove temporary images
-        run: |
-          HUB_TOKEN=$(
-            curl -s -H "Content-Type: application/json" \
-              -X POST \
-              -d "{\"username\": \"${{ secrets.GPUCIBOT_DOCKERHUB_USER }}\", \"password\": \"${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}\"}" \
-              https://hub.docker.com/v2/users/login/ | jq -r .token \
-          )
-          echo "::add-mask::${HUB_TOKEN}"
-
-          org="rapidsai"
-          base_repo="${{ needs.compute-matrix.outputs.BASE_IMAGE_REPO }}"
-          base_tag_array=(
-            ${{ needs.compute-matrix.outputs.BASE_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          base_tag="$(printf %s "${base_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-
-          notebooks_repo="${{ needs.compute-matrix.outputs.NOTEBOOKS_IMAGE_REPO }}"
-          notebooks_tag_array=(
-            ${{ needs.compute-matrix.outputs.NOTEBOOKS_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          notebooks_tag="$(printf %s "${notebooks_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          raft_ann_bench_repo="${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_IMAGE_REPO }}"
-          raft_ann_bench_tag_array=(
-            ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          raft_ann_bench_tag="$(printf %s "${raft_ann_bench_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          raft_ann_bench_datasets_repo="${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_IMAGE_REPO }}"
-          raft_ann_bench_datasets_tag_array=(
-            ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          raft_ann_bench_datasets_tag="$(printf %s "${raft_ann_bench_datasets_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          raft_ann_bench_cpu_repo="${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_IMAGE_REPO }}"
-          raft_ann_bench_cpu_tag_array=(
-            ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          raft_ann_bench_cpu_tag="$(printf %s "${raft_ann_bench_cpu_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          for arch in $(echo '${{ toJSON(matrix.ARCHES) }}' | jq .[] -r); do
-            curl -i -X DELETE \
-              -H "Accept: application/json" \
-              -H "Authorization: JWT $HUB_TOKEN" \
-              "https://hub.docker.com/v2/repositories/$org/$base_repo/tags/$base_tag-$arch/"
-            curl -i -X DELETE \
-              -H "Accept: application/json" \
-              -H "Authorization: JWT $HUB_TOKEN" \
-              "https://hub.docker.com/v2/repositories/$org/$notebooks_repo/tags/$notebooks_tag-$arch/"
-            curl -i -X DELETE \
-              -H "Accept: application/json" \
-              -H "Authorization: JWT $HUB_TOKEN" \
-              "https://hub.docker.com/v2/repositories/$org/$raft_ann_bench_repo/tags/$raft_ann_bench_tag-$arch/"
-            curl -i -X DELETE \
-              -H "Accept: application/json" \
-              -H "Authorization: JWT $HUB_TOKEN" \
-              "https://hub.docker.com/v2/repositories/$org/$raft_ann_bench_datasets_repo/tags/$raft_ann_bench_datasets_tag-$arch/"
-            curl -i -X DELETE \
-              -H "Accept: application/json" \
-              -H "Authorization: JWT $HUB_TOKEN" \
-              "https://hub.docker.com/v2/repositories/$org/$raft_ann_bench_cpu_repo/tags/$raft_ann_bench_cpu_tag-$arch/"
-          done
+        shell: bash
+        env:
+          BASE_IMAGE_REPO: ${{ needs.compute-matrix.outputs.BASE_IMAGE_REPO }}
+          BASE_TAG_PREFIX: ${{ needs.compute-matrix.outputs.BASE_TAG_PREFIX }}
+          RAPIDS_VER: ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
+          ALPHA_TAG: ${{ needs.compute-matrix.outputs.ALPHA_TAG }}
+          CUDA_TAG: ${{ matrix.CUDA_TAG }}
+          PYTHON_VER: ${{ matrix.PYTHON_VER }}
+          NOTEBOOKS_IMAGE_REPO: ${{ needs.compute-matrix.outputs.NOTEBOOKS_IMAGE_REPO }}
+          NOTEBOOKS_TAG_PREFIX: ${{ needs.compute-matrix.outputs.NOTEBOOKS_TAG_PREFIX }}
+          RAFT_ANN_BENCH_IMAGE_REPO: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_IMAGE_REPO }}
+          RAFT_ANN_BENCH_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_TAG_PREFIX }}
+          RAFT_ANN_BENCH_DATASETS_IMAGE_REPO: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_IMAGE_REPO }}
+          RAFT_ANN_BENCH_DATASETS_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_TAG_PREFIX }}
+          RAFT_ANN_BENCH_CPU_IMAGE_REPO: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_IMAGE_REPO }}
+          RAFT_ANN_BENCH_CPU_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_TAG_PREFIX }}
+          GPUCIBOT_DOCKERHUB_USER: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+          GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+          ARCHES: ${{ toJSON(matrix.ARCHES) }}
+        run: ci/delete-temp-images.sh

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -168,7 +168,7 @@ jobs:
         ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
         py${{ matrix.PYTHON_VER }}"
   build-multiarch-manifest:
-    if: '!cancelled()'
+    if: ${{ !cancelled() && inputs.build_type == 'branch' }}
     needs: [build, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -242,6 +242,7 @@ jobs:
       - name: Remove temporary images
         shell: bash
         env:
+          RAFT_ANN_BENCH_CPU_IMAGE_BUILT: ${{ matrix.CUDA_TAG == '12.5.1' }}
           BASE_IMAGE_REPO: ${{ needs.compute-matrix.outputs.BASE_IMAGE_REPO }}
           BASE_TAG_PREFIX: ${{ needs.compute-matrix.outputs.BASE_TAG_PREFIX }}
           RAPIDS_VER: ${{ needs.compute-matrix.outputs.RAPIDS_VER }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -191,10 +191,11 @@ jobs:
         py${{ matrix.PYTHON_VER }}-\
         ${{ matrix.ARCH }}"
   build-multiarch-manifest:
-    if: inputs.build_type == 'branch'
+    if: inputs.build_type == 'branch' && needs.build.result != 'cancelled'
     needs: [build, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -207,82 +208,27 @@ jobs:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
       - name: Create multiarch manifest
-        run: |
-          base_source_tags=()
-          notebooks_source_tags=()
-          raft_ann_bench_source_tags=()
-          raft_ann_bench_dataset_source_tags=()
-          raft_ann_bench_cpu_source_tags=()
+        shell: bash
+        env:
+          BASE_IMAGE_REPO: ${{ needs.compute-matrix.outputs.BASE_IMAGE_REPO }}
+          BASE_TAG_PREFIX: ${{ needs.compute-matrix.outputs.BASE_TAG_PREFIX }}
+          RAPIDS_VER: ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
+          ALPHA_TAG: ${{ needs.compute-matrix.outputs.ALPHA_TAG }}
+          CUDA_TAG: ${{ matrix.CUDA_TAG }}
+          PYTHON_VER: ${{ matrix.PYTHON_VER }}
+          NOTEBOOKS_IMAGE_REPO: ${{ needs.compute-matrix.outputs.NOTEBOOKS_IMAGE_REPO }}
+          NOTEBOOKS_TAG_PREFIX: ${{ needs.compute-matrix.outputs.NOTEBOOKS_TAG_PREFIX }}
+          RAFT_ANN_BENCH_IMAGE_REPO: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_IMAGE_REPO }}
+          RAFT_ANN_BENCH_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_TAG_PREFIX }}
+          RAFT_ANN_BENCH_DATASETS_IMAGE_REPO: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_IMAGE_REPO }}
+          RAFT_ANN_BENCH_DATASETS_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_TAG_PREFIX }}
+          RAFT_ANN_BENCH_CPU_IMAGE_REPO: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_IMAGE_REPO }}
+          RAFT_ANN_BENCH_CPU_TAG_PREFIX: ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_TAG_PREFIX }}
+          GPUCIBOT_DOCKERHUB_USER: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+          GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+        run: ci/create-multiarch-manifest.sh
 
-          base_tag_array=(
-            rapidsai/${{ needs.compute-matrix.outputs.BASE_IMAGE_REPO }}:
-            ${{ needs.compute-matrix.outputs.BASE_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          base_tag="$(printf %s "${base_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          notebooks_tag_array=(
-            rapidsai/${{ needs.compute-matrix.outputs.NOTEBOOKS_IMAGE_REPO }}:
-            ${{ needs.compute-matrix.outputs.NOTEBOOKS_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          notebooks_tag="$(printf %s "${notebooks_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          raft_ann_bench_tag_array=(
-            rapidsai/${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_IMAGE_REPO }}:
-            ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          raft_ann_bench_tag="$(printf %s "${raft_ann_bench_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          raft_ann_bench_datasets_tag_array=(
-            rapidsai/${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_IMAGE_REPO }}:
-            ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_DATASETS_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            cuda${{ matrix.CUDA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          raft_ann_bench_datasets_tag="$(printf %s "${raft_ann_bench_datasets_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          raft_ann_bench_cpu_tag_array=(
-            rapidsai/${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_IMAGE_REPO }}:
-            ${{ needs.compute-matrix.outputs.RAFT_ANN_BENCH_CPU_TAG_PREFIX }}
-            ${{ needs.compute-matrix.outputs.RAPIDS_VER }}
-            ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-
-            py${{ matrix.PYTHON_VER }}
-          )
-          raft_ann_bench_cpu_tag="$(printf %s "${raft_ann_bench_cpu_tag_array[@]}" $'\n')" # Converts array to string w/o spaces
-
-          for arch in $(echo '${{ toJSON(matrix.ARCHES) }}' | jq .[] -r); do
-            base_source_tags+=("${base_tag}-${arch}")
-            notebooks_source_tags+=("${notebooks_tag}-${arch}")
-            raft_ann_bench_source_tags+=("${raft_ann_bench_tag}-${arch}")
-            raft_ann_bench_datasets_source_tags+=("${raft_ann_bench_datasets_tag}-${arch}")
-            raft_ann_bench_cpu_source_tags+=("${raft_ann_bench_cpu_tag}-${arch}")
-          done
-
-          docker manifest create ${base_tag} ${base_source_tags[@]}
-          docker manifest push ${base_tag}
-          docker manifest create ${notebooks_tag} ${notebooks_source_tags[@]}
-          docker manifest push ${notebooks_tag}
-          docker manifest create ${raft_ann_bench_tag} ${raft_ann_bench_source_tags[@]}
-          docker manifest push ${raft_ann_bench_tag}
-          docker manifest create ${raft_ann_bench_datasets_tag} ${raft_ann_bench_datasets_source_tags[@]}
-          docker manifest push ${raft_ann_bench_datasets_tag}
-          docker manifest create ${raft_ann_bench_cpu_tag} ${raft_ann_bench_cpu_source_tags[@]}
-          docker manifest push ${raft_ann_bench_cpu_tag}
   delete-temp-images:
-    if: always()
     needs: [compute-matrix, build, test, build-multiarch-manifest]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -237,6 +237,10 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Remove temporary images
         shell: bash
         env:

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -167,29 +167,6 @@ jobs:
         ${{ needs.compute-matrix.outputs.RAPIDS_VER }}\
         ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
         py${{ matrix.PYTHON_VER }}"
-  test:
-    needs: [build, compute-matrix]
-    if: inputs.run_tests
-    strategy:
-      matrix: ${{ fromJSON(needs.compute-matrix.outputs.TEST_MATRIX) }}
-      fail-fast: false
-    secrets: inherit
-    uses: ./.github/workflows/test-notebooks.yml
-    with:
-      BUILD_TYPE: ${{ inputs.build_type }}
-      ARCH: ${{ matrix.ARCH }}
-      GPU: ${{ matrix.GPU }}
-      DRIVER: ${{ matrix.DRIVER }}
-      CUDA_VER: ${{ matrix.CUDA_VER }}
-      PYTHON_VER: ${{ matrix.PYTHON_VER }}
-      NOTEBOOKS_TAG:
-        "rapidsai/${{ needs.compute-matrix.outputs.NOTEBOOKS_IMAGE_REPO }}:\
-        ${{ needs.compute-matrix.outputs.NOTEBOOKS_TAG_PREFIX }}\
-        ${{ needs.compute-matrix.outputs.RAPIDS_VER }}\
-        ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
-        cuda${{ matrix.CUDA_VER }}-\
-        py${{ matrix.PYTHON_VER }}-\
-        ${{ matrix.ARCH }}"
   build-multiarch-manifest:
     if: '!cancelled()'
     needs: [build, compute-matrix]
@@ -228,10 +205,31 @@ jobs:
           GPUCIBOT_DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
           ARCHES: ${{ toJSON(matrix.ARCHES) }}
         run: ci/create-multiarch-manifest.sh
-
+  test:
+    needs: [compute-matrix, build, build-multiarch-manifest]
+    if: inputs.run_tests
+    strategy:
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.TEST_MATRIX) }}
+      fail-fast: false
+    secrets: inherit
+    uses: ./.github/workflows/test-notebooks.yml
+    with:
+      BUILD_TYPE: ${{ inputs.build_type }}
+      ARCH: ${{ matrix.ARCH }}
+      GPU: ${{ matrix.GPU }}
+      DRIVER: ${{ matrix.DRIVER }}
+      CUDA_VER: ${{ matrix.CUDA_VER }}
+      PYTHON_VER: ${{ matrix.PYTHON_VER }}
+      NOTEBOOKS_TAG:
+        "rapidsai/${{ needs.compute-matrix.outputs.NOTEBOOKS_IMAGE_REPO }}:\
+        ${{ needs.compute-matrix.outputs.NOTEBOOKS_TAG_PREFIX }}\
+        ${{ needs.compute-matrix.outputs.RAPIDS_VER }}\
+        ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
+        cuda${{ matrix.CUDA_VER }}-\
+        py${{ matrix.PYTHON_VER }}"
   delete-temp-images:
-    if: ${{ !cancelled() && needs.test.result == 'success' }}
-    needs: [compute-matrix, test, build-multiarch-manifest]
+    if: '!cancelled()'
+    needs: [compute-matrix, build-multiarch-manifest]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -230,7 +230,7 @@ jobs:
         run: ci/create-multiarch-manifest.sh
 
   delete-temp-images:
-    if: '!cancelled()'
+    if: ${{ !cancelled() && needs.test.result == 'success' }}
     needs: [compute-matrix, test, build-multiarch-manifest]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -228,8 +228,8 @@ jobs:
         cuda${{ matrix.CUDA_VER }}-\
         py${{ matrix.PYTHON_VER }}"
   delete-temp-images:
-    if: '!cancelled()'
-    needs: [compute-matrix, build-multiarch-manifest]
+    if: ${{ !cancelled() && needs.build-multiarch-manifest.result == 'success' }}
+    needs: [compute-matrix, build-multiarch-manifest, test]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -191,7 +191,7 @@ jobs:
         py${{ matrix.PYTHON_VER }}-\
         ${{ matrix.ARCH }}"
   build-multiarch-manifest:
-    if: inputs.build_type == 'branch' && needs.build.result != 'cancelled'
+    if: '!cancelled()'
     needs: [build, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -231,7 +231,7 @@ jobs:
 
   delete-temp-images:
     if: '!cancelled()'
-    needs: [compute-matrix, build-multiarch-manifest]
+    needs: [compute-matrix, test, build-multiarch-manifest]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false

--- a/ci/create-multiarch-manifest.sh
+++ b/ci/create-multiarch-manifest.sh
@@ -1,0 +1,78 @@
+# Authenticate and retrieve DockerHub token
+HUB_TOKEN=$(
+curl -s -H "Content-Type: application/json" \
+    -X POST \
+    -d "{\"username\": \"$GPUCIBOT_DOCKERHUB_USER\", \"password\": \"$GPUCIBOT_DOCKERHUB_TOKEN\"}" \
+    https://hub.docker.com/v2/users/login/ | jq -r .token \
+)
+echo "::add-mask::${HUB_TOKEN}"
+
+org="rapidsai"
+
+# Initialize arrays to store source tags for each image
+base_source_tags=()
+notebooks_source_tags=()
+raft_ann_bench_source_tags=()
+raft_ann_bench_datasets_source_tags=()
+raft_ann_bench_cpu_source_tags=()
+
+# Define tag arrays for different images
+base_tag="${BASE_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
+notebooks_tag="${NOTEBOOKS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
+raft_ann_bench_tag="${RAFT_ANN_BENCH_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
+raft_ann_bench_datasets_tag="${RAFT_ANN_BENCH_DATASETS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
+raft_ann_bench_cpu_tag="${RAFT_ANN_BENCH_CPU_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-py${PYTHON_VER}"
+
+# Function to check if a Docker tag exists
+check_tag_exists() {
+    local repo="$1"
+    local tag="$2"
+    local exists
+    exists=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: JWT $HUB_TOKEN" \
+        "https://hub.docker.com/v2/repositories/${org}/${repo}/tags/${tag}/")
+
+    if [ "$exists" -ne 200 ]; then
+        echo "Error: Required image tag ${repo}:${tag} does not exist. This implies that the image was not built successfully in the build job."
+        exit 1
+    fi
+}
+
+# Check if all source tags exist and add to source tags array
+for arch in $(echo '${{ toJSON(matrix.ARCHES) }}' | jq .[] -r); do
+    full_base_tag="${base_tag}-${arch}"
+    full_notebooks_tag="${notebooks_tag}-${arch}"
+    full_raft_ann_bench_tag="${raft_ann_bench_tag}-${arch}"
+    full_raft_ann_bench_datasets_tag="${raft_ann_bench_datasets_tag}-${arch}"
+    full_raft_ann_bench_cpu_tag="${raft_ann_bench_cpu_tag}-${arch}"
+
+    check_tag_exists "$BASE_IMAGE_REPO" "$full_base_tag"
+    base_source_tags+=("${org}/${BASE_IMAGE_REPO}:$full_base_tag")
+
+    check_tag_exists "$NOTEBOOKS_IMAGE_REPO" "$full_notebooks_tag"
+    notebooks_source_tags+=("${org}/${NOTEBOOKS_IMAGE_REPO}:$full_notebooks_tag")
+
+    check_tag_exists "$RAFT_ANN_BENCH_IMAGE_REPO" "$full_raft_ann_bench_tag"
+    raft_ann_bench_source_tags+=("${org}/${RAFT_ANN_BENCH_IMAGE_REPO}:$full_raft_ann_bench_tag")
+
+    check_tag_exists "$RAFT_ANN_BENCH_DATASETS_IMAGE_REPO" "$full_raft_ann_bench_datasets_tag"
+    raft_ann_bench_datasets_source_tags+=("${org}/${RAFT_ANN_BENCH_DATASETS_IMAGE_REPO}:$full_raft_ann_bench_datasets_tag")
+
+    check_tag_exists "$RAFT_ANN_BENCH_CPU_IMAGE_REPO" "$full_raft_ann_bench_cpu_tag"
+    raft_ann_bench_cpu_source_tags+=("${org}/${RAFT_ANN_BENCH_CPU_IMAGE_REPO}:$full_raft_ann_bench_cpu_tag")
+done
+
+# Create and push Docker multi-arch manifests
+docker manifest create "${org}/${BASE_IMAGE_REPO}:${base_tag}" "${base_source_tags[@]}"
+docker manifest push "${org}/${BASE_IMAGE_REPO}:${base_tag}"
+
+docker manifest create "${org}/${NOTEBOOKS_IMAGE_REPO}:${notebooks_tag}" "${notebooks_source_tags[@]}"
+docker manifest push "${org}/${NOTEBOOKS_IMAGE_REPO}:${notebooks_tag}"
+
+docker manifest create "${org}/${RAFT_ANN_BENCH_IMAGE_REPO}:${raft_ann_bench_tag}" "${raft_ann_bench_source_tags[@]}"
+docker manifest push "${org}/${RAFT_ANN_BENCH_IMAGE_REPO}:${raft_ann_bench_tag}"
+
+docker manifest create "${org}/${RAFT_ANN_BENCH_DATASETS_IMAGE_REPO}:${raft_ann_bench_datasets_tag}" "${raft_ann_bench_datasets_source_tags[@]}"
+docker manifest push "${org}/${RAFT_ANN_BENCH_DATASETS_IMAGE_REPO}:${raft_ann_bench_datasets_tag}"
+
+docker manifest create "${org}/${RAFT_ANN_BENCH_CPU_IMAGE_REPO}:${raft_ann_bench_cpu_tag}" "${raft_ann_bench_cpu_source_tags[@]}"
+docker manifest push "${org}/${RAFT_ANN_BENCH_CPU_IMAGE_REPO}:${raft_ann_bench_cpu_tag}"

--- a/ci/create-multiarch-manifest.sh
+++ b/ci/create-multiarch-manifest.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
 # Authenticate and retrieve DockerHub token
 HUB_TOKEN=$(
 curl -s -H "Content-Type: application/json" \

--- a/ci/create-multiarch-manifest.sh
+++ b/ci/create-multiarch-manifest.sh
@@ -1,5 +1,3 @@
-set -x
-
 # Authenticate and retrieve DockerHub token
 HUB_TOKEN=$(
 curl -s -H "Content-Type: application/json" \

--- a/ci/delete-temp-images.sh
+++ b/ci/delete-temp-images.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
 # Authenticate and retrieve DockerHub token
 HUB_TOKEN=$(
 curl -s -H "Content-Type: application/json" \

--- a/ci/delete-temp-images.sh
+++ b/ci/delete-temp-images.sh
@@ -1,5 +1,3 @@
-set -x
-
 # Authenticate and retrieve DockerHub token
 HUB_TOKEN=$(
 curl -s -H "Content-Type: application/json" \

--- a/ci/delete-temp-images.sh
+++ b/ci/delete-temp-images.sh
@@ -11,13 +11,6 @@ echo "::add-mask::${HUB_TOKEN}"
 
 org="rapidsai"
 
-# Initialize arrays to store source tags for each image
-base_source_tags=()
-notebooks_source_tags=()
-raft_ann_bench_source_tags=()
-raft_ann_bench_datasets_source_tags=()
-raft_ann_bench_cpu_source_tags=()
-
 # Define tag arrays for different images
 base_tag="${BASE_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
 notebooks_tag="${NOTEBOOKS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
@@ -25,7 +18,6 @@ raft_ann_bench_tag="${RAFT_ANN_BENCH_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${
 raft_ann_bench_datasets_tag="${RAFT_ANN_BENCH_DATASETS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
 raft_ann_bench_cpu_tag="${RAFT_ANN_BENCH_CPU_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-py${PYTHON_VER}"
 
-# Function to check if a Docker tag exists
 check_tag_exists() {
     local repo="$1"
     local tag="$2"
@@ -39,7 +31,6 @@ check_tag_exists() {
     fi
 }
 
-# Check if all source tags exist and add to source tags array
 for arch in $(echo "${ARCHES}" | jq .[] -r); do
     full_base_tag="${base_tag}-${arch}"
     full_notebooks_tag="${notebooks_tag}-${arch}"
@@ -48,33 +39,32 @@ for arch in $(echo "${ARCHES}" | jq .[] -r); do
     full_raft_ann_bench_cpu_tag="${raft_ann_bench_cpu_tag}-${arch}"
 
     check_tag_exists "$BASE_IMAGE_REPO" "$full_base_tag"
-    base_source_tags+=("${org}/${BASE_IMAGE_REPO}:$full_base_tag")
+    curl -i -X DELETE \
+        -H "Accept: application/json" \
+        -H "Authorization: JWT $HUB_TOKEN" \
+        "https://hub.docker.com/v2/repositories/$org/$BASE_IMAGE_REPO/tags/$base_tag-$arch/"
 
     check_tag_exists "$NOTEBOOKS_IMAGE_REPO" "$full_notebooks_tag"
-    notebooks_source_tags+=("${org}/${NOTEBOOKS_IMAGE_REPO}:$full_notebooks_tag")
+    curl -i -X DELETE \
+        -H "Accept: application/json" \
+        -H "Authorization: JWT $HUB_TOKEN" \
+        "https://hub.docker.com/v2/repositories/$org/$NOTEBOOKS_IMAGE_REPO/tags/$notebooks_tag-$arch/"
 
     check_tag_exists "$RAFT_ANN_BENCH_IMAGE_REPO" "$full_raft_ann_bench_tag"
-    raft_ann_bench_source_tags+=("${org}/${RAFT_ANN_BENCH_IMAGE_REPO}:$full_raft_ann_bench_tag")
+    curl -i -X DELETE \
+        -H "Accept: application/json" \
+        -H "Authorization: JWT $HUB_TOKEN" \
+        "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_IMAGE_REPO/tags/$raft_ann_bench_tag-$arch/"
 
     check_tag_exists "$RAFT_ANN_BENCH_DATASETS_IMAGE_REPO" "$full_raft_ann_bench_datasets_tag"
-    raft_ann_bench_datasets_source_tags+=("${org}/${RAFT_ANN_BENCH_DATASETS_IMAGE_REPO}:$full_raft_ann_bench_datasets_tag")
+    curl -i -X DELETE \
+        -H "Accept: application/json" \
+        -H "Authorization: JWT $HUB_TOKEN" \
+        "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_DATASETS_IMAGE_REPO/tags/$raft_ann_bench_datasets_tag-$arch/"
 
     check_tag_exists "$RAFT_ANN_BENCH_CPU_IMAGE_REPO" "$full_raft_ann_bench_cpu_tag"
-    raft_ann_bench_cpu_source_tags+=("${org}/${RAFT_ANN_BENCH_CPU_IMAGE_REPO}:$full_raft_ann_bench_cpu_tag")
+    curl -i -X DELETE \
+        -H "Accept: application/json" \
+        -H "Authorization: JWT $HUB_TOKEN" \
+        "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_CPU_IMAGE_REPO/tags/$raft_ann_bench_cpu_tag-$arch/"
 done
-
-# Create and push Docker multi-arch manifests
-docker manifest create "${org}/${BASE_IMAGE_REPO}:${base_tag}" "${base_source_tags[@]}"
-docker manifest push "${org}/${BASE_IMAGE_REPO}:${base_tag}"
-
-docker manifest create "${org}/${NOTEBOOKS_IMAGE_REPO}:${notebooks_tag}" "${notebooks_source_tags[@]}"
-docker manifest push "${org}/${NOTEBOOKS_IMAGE_REPO}:${notebooks_tag}"
-
-docker manifest create "${org}/${RAFT_ANN_BENCH_IMAGE_REPO}:${raft_ann_bench_tag}" "${raft_ann_bench_source_tags[@]}"
-docker manifest push "${org}/${RAFT_ANN_BENCH_IMAGE_REPO}:${raft_ann_bench_tag}"
-
-docker manifest create "${org}/${RAFT_ANN_BENCH_DATASETS_IMAGE_REPO}:${raft_ann_bench_datasets_tag}" "${raft_ann_bench_datasets_source_tags[@]}"
-docker manifest push "${org}/${RAFT_ANN_BENCH_DATASETS_IMAGE_REPO}:${raft_ann_bench_datasets_tag}"
-
-docker manifest create "${org}/${RAFT_ANN_BENCH_CPU_IMAGE_REPO}:${raft_ann_bench_cpu_tag}" "${raft_ann_bench_cpu_source_tags[@]}"
-docker manifest push "${org}/${RAFT_ANN_BENCH_CPU_IMAGE_REPO}:${raft_ann_bench_cpu_tag}"

--- a/ci/delete-temp-images.sh
+++ b/ci/delete-temp-images.sh
@@ -60,9 +60,11 @@ for arch in $(echo "${ARCHES}" | jq .[] -r); do
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_DATASETS_IMAGE_REPO/tags/$raft_ann_bench_datasets_tag-$arch/"
 
-    check_tag_exists "$RAFT_ANN_BENCH_CPU_IMAGE_REPO" "$full_raft_ann_bench_cpu_tag"
-    curl -i -X DELETE \
-        -H "Accept: application/json" \
-        -H "Authorization: JWT $HUB_TOKEN" \
-        "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_CPU_IMAGE_REPO/tags/$raft_ann_bench_cpu_tag-$arch/"
+    if [ "$RAFT_ANN_BENCH_CPU_IMAGE_BUILT" = "true" ]; then
+        check_tag_exists "$RAFT_ANN_BENCH_CPU_IMAGE_REPO" "$full_raft_ann_bench_cpu_tag"
+        curl -i -X DELETE \
+            -H "Accept: application/json" \
+            -H "Authorization: JWT $HUB_TOKEN" \
+            "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_CPU_IMAGE_REPO/tags/$raft_ann_bench_cpu_tag-$arch/"
+    fi
 done

--- a/ci/delete-temp-images.sh
+++ b/ci/delete-temp-images.sh
@@ -16,52 +16,28 @@ raft_ann_bench_tag="${RAFT_ANN_BENCH_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${
 raft_ann_bench_datasets_tag="${RAFT_ANN_BENCH_DATASETS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
 raft_ann_bench_cpu_tag="${RAFT_ANN_BENCH_CPU_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-py${PYTHON_VER}"
 
-check_tag_exists() {
-    local repo="$1"
-    local tag="$2"
-    local exists
-    exists=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: JWT $HUB_TOKEN" \
-        "https://hub.docker.com/v2/repositories/${org}/${repo}/tags/${tag}/")
-
-    if [ "$exists" -ne 200 ]; then
-        echo "Error: Required image tag ${repo}:${tag} does not exist. This implies that the image was not built successfully in the build job."
-        exit 1
-    fi
-}
-
 for arch in $(echo "${ARCHES}" | jq .[] -r); do
-    full_base_tag="${base_tag}-${arch}"
-    full_notebooks_tag="${notebooks_tag}-${arch}"
-    full_raft_ann_bench_tag="${raft_ann_bench_tag}-${arch}"
-    full_raft_ann_bench_datasets_tag="${raft_ann_bench_datasets_tag}-${arch}"
-    full_raft_ann_bench_cpu_tag="${raft_ann_bench_cpu_tag}-${arch}"
-
-    check_tag_exists "$BASE_IMAGE_REPO" "$full_base_tag"
     curl -i -X DELETE \
         -H "Accept: application/json" \
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/repositories/$org/$BASE_IMAGE_REPO/tags/$base_tag-$arch/"
 
-    check_tag_exists "$NOTEBOOKS_IMAGE_REPO" "$full_notebooks_tag"
     curl -i -X DELETE \
         -H "Accept: application/json" \
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/repositories/$org/$NOTEBOOKS_IMAGE_REPO/tags/$notebooks_tag-$arch/"
 
-    check_tag_exists "$RAFT_ANN_BENCH_IMAGE_REPO" "$full_raft_ann_bench_tag"
     curl -i -X DELETE \
         -H "Accept: application/json" \
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_IMAGE_REPO/tags/$raft_ann_bench_tag-$arch/"
 
-    check_tag_exists "$RAFT_ANN_BENCH_DATASETS_IMAGE_REPO" "$full_raft_ann_bench_datasets_tag"
     curl -i -X DELETE \
         -H "Accept: application/json" \
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/repositories/$org/$RAFT_ANN_BENCH_DATASETS_IMAGE_REPO/tags/$raft_ann_bench_datasets_tag-$arch/"
 
     if [ "$RAFT_ANN_BENCH_CPU_IMAGE_BUILT" = "true" ]; then
-        check_tag_exists "$RAFT_ANN_BENCH_CPU_IMAGE_REPO" "$full_raft_ann_bench_cpu_tag"
         curl -i -X DELETE \
             -H "Accept: application/json" \
             -H "Authorization: JWT $HUB_TOKEN" \


### PR DESCRIPTION
**Approach**:

1. Enable the construction of multi-architecture images even if not all image build matrices are successful. This allows for the publishing of manifests for the images that have been successfully built without waiting for all builds to complete.
    - In this change, we also modify the multi-arch job to only generate a manifest when the necessary images are available; otherwise, we make the job fail.
2. Modify the deletion job to execute only after the publishing and tests jobs succeed. This prevents the need to restart all jobs when a single image build job fails.


**Here are the new behaviors**:
- The `build-multiarch-manifest` no longer depends on the `build` jobs to all pass before publishing multi-arch images to dockerhub. Once the `build` job completes (either succeeds or fails), the multiarch job builds and pushes manifests for the succeeding images.
- The `test` job _still_ uses the images from `build` to run tests.
- The `delete-temp-images` job will only run AFTER `build-multiarch-manifest` and `test` jobs succeed.
- If any jobs fail during the workflow run, we can simply `re-run all failed jobs` now. Once all jobs pass, the delete job will trigger.