### PR TITLE
Readd fixed cuSpatial notebooks

### DIFF
--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -28,11 +28,6 @@ ignored_notebooks = [
     'cugraph/algorithms/layout/Force-Atlas2.ipynb',
     'cuspatial/binary_predicates.ipynb',
     'cuspatial/cuproj_benchmark.ipynb',
-    # context on these being skipped: https://github.com/rapidsai/cuspatial/pull/1407
-    'cuspatial/cuspatial_api_examples.ipynb',
-    'cuspatial/nyc_taxi_years_correlation.ipynb',
-    # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
-    'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
 ]
 
 


### PR DESCRIPTION
These cuSpatial notebooks ran into some issues near the 24.08 release. We opted to skip them and work on fixes in 24.10. As those fixes are now landing, try adding these notebooks back

* https://github.com/rapidsai/cuspatial/pull/1407
* https://github.com/rapidsai/cuspatial/issues/1426
* https://github.com/rapidsai/cuspatial/pull/1424