### PR TITLE
resolve warnings about Dockerfile casing

### DIFF
--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -3,7 +3,7 @@
 ARG PYTHON_VER=3.11
 ARG RAPIDS_VER=24.10
 
-FROM condaforge/mambaforge:23.3.1-0 as raft-ann-bench-cpu
+FROM condaforge/mambaforge:23.3.1-0 AS raft-ann-bench-cpu
 ARG RAPIDS_VER
 ARG PYTHON_VER
 
@@ -47,7 +47,7 @@ CMD ["--dataset fashion-mnist-784-euclidean", "", "--algorithms hnswlib"]
 ENTRYPOINT ["/bin/bash", "/data/scripts/run_benchmark.sh"]
 
 
-FROM bench-base as raft-ann-bench-cpu-datasets
+FROM bench-base AS raft-ann-bench-cpu-datasets
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -6,7 +6,7 @@ ARG LINUX_VER=ubuntu22.04
 
 ARG RAPIDS_VER=24.10
 
-FROM rapidsai/miniforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} as raft-ann-bench
+FROM rapidsai/miniforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} AS raft-ann-bench
 ARG CUDA_VER
 ARG RAPIDS_VER
 
@@ -50,7 +50,7 @@ CMD ["--dataset fashion-mnist-784-euclidean", "", "--algorithms raft_cagra", ""]
 ENTRYPOINT ["/bin/bash", "/data/scripts/run_benchmark.sh"]
 
 
-FROM raft-ann-bench as raft-ann-bench-datasets
+FROM raft-ann-bench AS raft-ann-bench-datasets
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 


### PR DESCRIPTION
Reviewing #706, I noticed the following on the Files tab (https://github.com/rapidsai/docker/pull/706/files):

> FromAsCasing: 'as' and 'FROM' keywords' casing do not match
> More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

<img width="1285" alt="image" src="https://github.com/user-attachments/assets/66191c7f-77d9-415c-b965-b7e039df49fa">

This resolves those warnings. They don't change anything functionally, but I do slightly agree with the style suggestion, and it'd be nice to remove the visual noise of all those warnings in PR reviews.