### PR TITLE
ensure test jobs always run on PRs

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -38,6 +38,7 @@ jobs:
       - compute-matrix
       - build
       - test
+      - delete-temp-images
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
   checks:
@@ -249,7 +250,8 @@ jobs:
         ${{ needs.compute-matrix.outputs.RAPIDS_VER }}\
         ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
         cuda${{ matrix.CUDA_VER }}-\
-        py${{ matrix.PYTHON_VER }}"
+        py${{ matrix.PYTHON_VER }}"-\
+        ${{ matrix.ARCH }}
   delete-temp-images:
     if: ${{ !cancelled() && needs.test.result == 'success' }}
     needs: [compute-matrix, build, test]

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -31,6 +31,13 @@ permissions:
   statuses: none
 
 jobs:
+  pr-builder:
+    needs:
+      - compute-matrix
+      - build
+      - test
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
   compute-matrix:
     runs-on: ubuntu-latest
     container:
@@ -208,7 +215,7 @@ jobs:
           ARCHES: ${{ toJSON(matrix.ARCHES) }}
         run: ci/create-multiarch-manifest.sh
   test:
-    needs: [compute-matrix, build, build-multiarch-manifest]
+    needs: [compute-matrix, build]
     if: inputs.run_tests
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.TEST_MATRIX) }}
@@ -231,7 +238,7 @@ jobs:
         py${{ matrix.PYTHON_VER }}"
   delete-temp-images:
     if: ${{ !cancelled() && needs.test.result == 'success' }}
-    needs: [compute-matrix, build-multiarch-manifest, test]
+    needs: [compute-matrix, build, test]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -250,8 +250,8 @@ jobs:
         ${{ needs.compute-matrix.outputs.RAPIDS_VER }}\
         ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
         cuda${{ matrix.CUDA_VER }}-\
-        py${{ matrix.PYTHON_VER }}"-\
-        ${{ matrix.ARCH }}
+        py${{ matrix.PYTHON_VER }}-\
+        ${{ matrix.ARCH }}"
   delete-temp-images:
     if: ${{ !cancelled() && needs.test.result == 'success' }}
     needs: [compute-matrix, build, test]

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -32,12 +32,26 @@ permissions:
 
 jobs:
   pr-builder:
+    if: ${{ !cancelled() && inputs.build_type == 'pull-request' }}
     needs:
+      - checks
       - compute-matrix
       - build
       - test
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
   compute-matrix:
     runs-on: ubuntu-latest
     container:
@@ -126,7 +140,7 @@ jobs:
 
           echo "TEST_MATRIX=$(yq -n -o json 'env(TEST_MATRIX)' | jq -c '{include: .}')" | tee --append "${GITHUB_OUTPUT}"
   build:
-    needs: compute-matrix
+    needs: [checks, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -37,6 +37,7 @@ jobs:
       - checks
       - compute-matrix
       - build
+      - build-multiarch-manifest
       - test
       - delete-temp-images
     secrets: inherit
@@ -46,9 +47,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
       - name: Run pre-commit
         run: |
           pip install pre-commit
@@ -191,7 +189,6 @@ jobs:
         ${{ needs.compute-matrix.outputs.ALPHA_TAG }}-\
         py${{ matrix.PYTHON_VER }}"
   build-multiarch-manifest:
-    if: ${{ !cancelled() && inputs.build_type == 'branch' }}
     needs: [build, compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
@@ -253,8 +250,8 @@ jobs:
         py${{ matrix.PYTHON_VER }}-\
         ${{ matrix.ARCH }}"
   delete-temp-images:
-    if: ${{ !cancelled() && needs.test.result == 'success' }}
-    needs: [compute-matrix, build, test]
+    if: ${{ !cancelled() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
+    needs: [compute-matrix, build, build-multiarch-manifest, test]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,26 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-builder:
-    needs:
-      - checks
-      - docker
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
-  checks:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Run pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit run --all-files
   docker:
-    needs: [checks]
     uses: ./.github/workflows/build-test-publish-images.yml
     with:
       build_type: pull-request


### PR DESCRIPTION
Follow-up to #702 and #693.

Created based on https://github.com/rapidsai/docker/pull/696#issuecomment-2289689619

`test` jobs are not currently running on pull requests here, because they require `build-multiarch-manifest` jobs, which have this condition that causes such jobs to be skipped on PR builds:

https://github.com/rapidsai/docker/blob/1c27d9245fd9d99ee35981b970acaf10961ca45b/.github/workflows/build-test-publish-images.yml#L171-L172

This PR ensures that `test` jobs always run on PRs, and that merging is blocked until they succeed.