### PR TITLE
raft-ann-bench images: update conda sooner

### DIFF
--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -23,10 +23,11 @@ EOF
 # we need perl temporarily for the remaining benchmark perl scripts
 RUN apt-get install perl -y
 
-# Install python before updating environment, otherwise Python 3 image
-# runs into a solver conflict with truststore 0.8.0. This avoids the environment installing
-# packages incompatible with python version needed before python itself is pinned to the correct version.
+# update everything before other environment changes, to ensure mixing
+# an older conda with newer packages still works well
+# ref: https://github.com/rapidsai/ci-imgs/issues/185
 RUN <<EOF
+mamba update --all -y -n base
 mamba install -y -n base "python=${PYTHON_VER}"
 mamba update --all -y -n base
 mamba install -y -n base \

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -26,8 +26,6 @@ EOF
 # we need perl temporarily for the remaining benchmark perl scripts
 RUN apt-get install perl -y
 
-# temporarily downgrade conda from 23.9.0 due to https://github.com/mamba-org/mamba/issues/2882
-# after the mamba update step
 RUN <<EOF
 mamba update --all -y -n base
 mamba install -y -n base \


### PR DESCRIPTION
Nightly builds of `rapidsai/raft-ann-bench` failed like this:

> ImportError: /lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /opt/conda/lib/python3.11/site-packages/libmambapy/bindings.cpython-311-aarch64-linux-gnu.so)

([build link](https://github.com/rapidsai/docker/actions/runs/10739898324/job/29789780257))

I suspect that's because those images use the same pattern for initializing a conda environment that led to the issues described in https://github.com/rapidsai/ci-imgs/issues/185.

This proposes the same fix that we applied in `ci-imgs` (https://github.com/rapidsai/ci-imgs/pull/186).