### PR TITLE
add Python 3.12 images, default to Python 3.12 and CUDA 12.5 in docs

### DIFF
--- a/dockerhub-readme.md
+++ b/dockerhub-readme.md
@@ -39,7 +39,7 @@ There are two types:
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-24.10-cuda11.8-py3.11
+24.10-cuda12.5-py3.12
  ^        ^      ^
  |        |      Python version
  |        |
@@ -48,7 +48,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
  RAPIDS version
 ```
 
-**Note: Nightly builds of the images have the RAPIDS version appended with an `a` (ie `24.10a-cuda11.8-py3.11`)**
+**Note: Nightly builds of the images have the RAPIDS version appended with an `a` (ie `24.10a-cuda12.5-py3.12`)**
 
 ## Usage
 
@@ -81,7 +81,7 @@ $ docker run \
     -e EXTRA_CONDA_PACKAGES="jq" \
     -e EXTRA_PIP_PACKAGES="beautifulsoup4" \
     -p 8888:8888 \
-    rapidsai/notebooks:24.10-cuda11.8-py3.11
+    rapidsai/notebooks:24.10-cuda12.5-py3.12
 ```
 
 ### Bind Mounts
@@ -106,7 +106,7 @@ $ docker run \
     --gpus all \
     -shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
     -v $(pwd)/environment.yml:/home/rapids/environment.yml \
-    rapidsai/base:24.10-cuda11.8-py3.11
+    rapidsai/base:24.10-cuda12.5-py3.12
 ```
 
 ### Use JupyterLab to Explore the Notebooks

--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -2,8 +2,8 @@
 
 pull-request:
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
-  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'arm64', PYTHON_VER: '3.12', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.5', ARCH: 'amd64', PYTHON_VER: '3.12', GPU: 'v100', DRIVER: 'latest' }
 branch:
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }

--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -2,12 +2,12 @@
 
 pull-request:
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
-  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.5', ARCH: 'arm64', PYTHON_VER: '3.12', GPU: 'v100', DRIVER: 'latest' }
 branch:
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
   - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.5', ARCH: 'amd64', PYTHON_VER: '3.12', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '12.5', ARCH: 'arm64', PYTHON_VER: '3.12', GPU: 'a100', DRIVER: 'latest' }

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,7 +1,8 @@
-CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `11.2.2`)
+CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `12.5.1`)
   - "11.8.0"
   - "12.0.1"
   - "12.5.1"
 PYTHON_VER:
   - "3.10"
   - "3.11"
+  - "3.12"

--- a/raft-ann-bench/README.md
+++ b/raft-ann-bench/README.md
@@ -36,7 +36,7 @@ export DATA_FOLDER=path/to/store/results/and/data
 docker run --gpus all --rm -it \
     -v $DATA_FOLDER:/home/rapids/benchmarks  \
     -u $(id -u) \
-    rapidsai/raft-ann-bench:24.10a-cuda11.8-py3.11 \
+    rapidsai/raft-ann-bench:24.10a-cuda12.5-py3.12 \
     "--dataset deep-image-96-angular" \
     "--normalize" \
     "--algorithms raft_cagra" \
@@ -50,7 +50,7 @@ export DATA_FOLDER=path/to/store/results/and/data # <- Results and datasets will
 docker run --gpus all --rm -it \
     -v $DATA_FOLDER:/home/rapids/benchmarks  \ # <- local folder to store datasets and results
     -u $(id -u) \ # <- this flag allows the container to use the host user for permissions
-    rapidsai/raft-ann-bench:24.10a-cuda11.8-py3.11 \ # <- image to use, either `raft-ann-bench` or `raft-ann-bench-datasets`
+    rapidsai/raft-ann-bench:24.10a-cuda12.5-py3.12 \ # <- image to use, either `raft-ann-bench` or `raft-ann-bench-datasets`
     "--dataset deep-image-96-angular" \ # <- dataset name
     "--normalize" \ # <- whether to normalize the dataset, leave string empty ("") to not normalize.
     "--algorithms raft_cagra" \ # <- what algorithm(s) to use as a ; separated list, as well as any other argument to pass to `raft_ann_benchmarks.run`
@@ -63,7 +63,7 @@ export DATA_FOLDER=path/to/store/results/and/data
 docker run  all --rm -it \
     -v $DATA_FOLDER:/home/rapids/benchmarks  \
     -u $(id -u) \ # <- this flag allows the container to use the host user for permissions
-    rapidsai/raft-ann-bench-cpu:24.10a-py3.11 \
+    rapidsai/raft-ann-bench-cpu:24.10a-py3.12 \
      "--dataset deep-image-96-angular" \
      "--normalize" \
      "--algorithms raft_cagra" \
@@ -77,7 +77,7 @@ export DATA_FOLDER=path/to/store/results/and/data
 docker run --gpus all --rm -it \
     -v $DATA_FOLDER:/home/rapids/benchmarks  \
     -u $(id -u) \
-    rapidsai/raft-ann-bench:24.10a-cuda11.8-py3.11 \
+    rapidsai/raft-ann-bench:24.10a-cuda12.5-py3.12 \
     --entrypoint /bin/bash
 ```
 

--- a/raft-ann-bench/cpu/Dockerfile
+++ b/raft-ann-bench/cpu/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHON_VER=3.11
-ARG RAPIDS_VER=24.10
+ARG PYTHON_VER=unset
+ARG RAPIDS_VER=unset
 
 FROM condaforge/mambaforge:23.3.1-0 AS raft-ann-bench-cpu
 ARG RAPIDS_VER

--- a/raft-ann-bench/gpu/Dockerfile
+++ b/raft-ann-bench/gpu/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
-ARG CUDA_VER=12.0.1
-ARG PYTHON_VER=3.11
-ARG LINUX_VER=ubuntu22.04
+ARG CUDA_VER=unset
+ARG PYTHON_VER=unset
+ARG LINUX_VER=unset
 
-ARG RAPIDS_VER=24.10
+ARG RAPIDS_VER=unset
 
 FROM rapidsai/miniforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} AS raft-ann-bench
 ARG CUDA_VER


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/40.

* adds Python 3.12 images
* defaults to latest Python (3.12) and CUDA (12.5[.1]) in docs and comments

## Notes for Reviewers

Builds here will fail until all RAPIDS libraries are supporting Python 3.12, but figured we don't need to wait on that to come to an agreement about the building and testing matrices.

Blocked by:

* [x] https://github.com/rapidsai/cuml/pull/6060
* [x] https://github.com/rapidsai/cugraph/pull/4647
* [x] https://github.com/rapidsai/integration/pull/719