### PR TITLE
avoid interactive prompts when updating from an environment.yaml

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -10,7 +10,7 @@ EOF
 
 if [ -e "/home/rapids/environment.yml" ]; then
     echo "environment.yml found. Installing packages."
-    timeout ${CONDA_TIMEOUT:-600} mamba env update -n base -f /home/rapids/environment.yml || exit $?
+    timeout ${CONDA_TIMEOUT:-600} mamba env update -n base -y -f /home/rapids/environment.yml || exit $?
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -31,6 +31,8 @@ ignored_notebooks = [
     # context on these being skipped: https://github.com/rapidsai/cuspatial/pull/1407
     'cuspatial/cuspatial_api_examples.ipynb',
     'cuspatial/nyc_taxi_years_correlation.ipynb',
+    # details: https://github.com/rapidsai/docker/issues/726
+    'cuspatial/trajectory_clustering.ipynb',
     # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
     'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
 ]

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -31,11 +31,9 @@ ignored_notebooks = [
     # context on these being skipped: https://github.com/rapidsai/cuspatial/pull/1407
     'cuspatial/cuspatial_api_examples.ipynb',
     'cuspatial/nyc_taxi_years_correlation.ipynb',
-    # details: https://github.com/rapidsai/docker/issues/726
-    'cuspatial/trajectory_clustering.ipynb',
     # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
     'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
-    # context on this being skipped: https://github.com/rapidsai/docker/pull/728#issuecomment-2631146036
+    # context on this being skipped: https://github.com/rapidsai/docker/issues/726
     'cuspatial/trajectory_clustering.ipynb',
 ]
 


### PR DESCRIPTION
Working with @taureandyernv yesterday, we tried something like this to patch in a dependency at run time.

```shell
cat > ./environment.yml <<EOF
channels:
- dglteam/label/th23_cu121
dependencies:
- dgl
EOF

docker run \
  --rm \
  -v $(pwd)/environment.yml:/home/rapids/environment.yml \
  -it rapidsai/base:25.02a-cuda12.5-py3.12 \
  conda env export
```

Found that that prompts for confirmation:

```text
  Package           Version  Build    Channel                       Size
──────────────────────────────────────────────────────────────────────────
  Install:
──────────────────────────────────────────────────────────────────────────

  + dgl    2.4.0.th23.cu121  py312_0  dglteam/label/th23_cu121     295MB

  Summary:
  Install: 1 packages
  Total download: 295MB

──────────────────────────────────────────────────────────────────────────

Confirm changes: [Y/n]
```

But that prompt seems not to make it through to `mamba`.

And even if that did work, this interactive prompt prevents the use of the "mount in an `environment.yml`" approach in situations where you aren't running the container interactively... for example, where you want to use this image in a container in a Kubernetes Pod, and provide an `environment.yml` via a ConfigMap or file Secret.

This proposes skipping the confirmation and always running `mamba env update -y` when an `environment.yml` is provided.

## Notes for Reviewers

### How I tested this

Pulled an image built from this PR and confirmed that that install pattern described above works and does not prompt for interactive input.

```shell
cat > ./environment.yml <<EOF
channels:
- dglteam/label/th23_cu121
dependencies:
- dgl
EOF

docker run \
  --rm \
  -v $(pwd)/environment.yml:/home/rapids/environment.yml \
  -it rapidsai/staging:docker-727-25.02a-cuda12.5-py3.12 \
  conda env export
```

```text
...
  - dgl=2.4.0.th23.cu121=py312_0
...
```
