### PR TITLE
Migrate to NVKS for amd64 CI runners

### DIFF
--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -1,13 +1,13 @@
 # CUDA_VER is `<major>.<minor>` (e.g. `12.0`)
 
 pull-request:
-  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
-  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'amd64', PYTHON_VER: '3.12', GPU: 'v100', DRIVER: 'latest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'earliest' }
+  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest'   }
+  - { CUDA_VER: '12.8', ARCH: 'amd64', PYTHON_VER: '3.12', GPU: 'l4',   DRIVER: 'latest'   }
 branch:
-  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'earliest' }
-  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'amd64', PYTHON_VER: '3.12', GPU: 'v100', DRIVER: 'latest' }
-  - { CUDA_VER: '12.5', ARCH: 'arm64', PYTHON_VER: '3.12', GPU: 'a100', DRIVER: 'latest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'earliest' }
+  - { CUDA_VER: '11.8', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'latest'   }
+  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.11', GPU: 'l4',   DRIVER: 'latest'   }
+  - { CUDA_VER: '12.0', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest'   }
+  - { CUDA_VER: '12.8', ARCH: 'amd64', PYTHON_VER: '3.12', GPU: 'l4',   DRIVER: 'latest'   }
+  - { CUDA_VER: '12.8', ARCH: 'arm64', PYTHON_VER: '3.12', GPU: 'a100', DRIVER: 'latest'   }

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,7 +1,7 @@
 CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `12.5.1`)
   - "11.8.0"
   - "12.0.1"
-  - "12.5.1"
+  - "12.8.0"
 PYTHON_VER:
   - "3.10"
   - "3.11"


### PR DESCRIPTION
This migrates amd64 CI jobs to use L4 GPUs from the NVKS cluster.

xref: https://github.com/rapidsai/build-infra/issues/184
