### PR TITLE
Enable label checker ops-bot plugin

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -4,3 +4,4 @@
 auto_merger: true
 branch_checker: true
 forward_merger: true
+label_checker: true


### PR DESCRIPTION
Activates the label-checker function described here: https://docs.rapids.ai/resources/label-checker/
