### PR TITLE
Set NCCL_CUMEM_HOST_ENABLE=0 for ARM with CUDA 12.8

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 
 if [ "$(uname -m)" = "aarch64" ]; then
     # Check if the CUDA version is 12.8
-    if nvcc --version | grep -q "CUDA 12.8"; then
+    if [[ "$CUDA_VERSION" = 12.8* ]]; then
         export NCCL_CUMEM_HOST_ENABLE=0
         echo "Set NCCL_CUMEM_HOST_ENABLE=0 for ARM with CUDA 12.8"
     fi

--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -23,6 +23,14 @@ if [ "$EXTRA_PIP_PACKAGES" ]; then
     timeout ${PIP_TIMEOUT:-600} pip install $EXTRA_PIP_PACKAGES || exit $?
 fi
 
+if [ "$(uname -m)" = "aarch64" ]; then
+    # Check if the CUDA version is 12.8
+    if nvcc --version | grep -q "CUDA 12.8"; then
+        export NCCL_CUMEM_HOST_ENABLE=0
+        echo "Set NCCL_CUMEM_HOST_ENABLE=0 for ARM with CUDA 12.8"
+    fi
+fi
+
 # Run whatever the user wants.
 if [ "${UNQUOTE}" = "true" ]; then
     exec $@


### PR DESCRIPTION
25.02 ARM containers on CUDA 12.8 are running into an issue of a get_mempolicy call that requires elevated privileges. This very likely will not be desirable for many users, so this change sets the environment NCCL_CUMEM_HOST_ENABLE=0 inside the container that removes the call and makes the containers work similar to prior versions.

This bug only affects RAPIDS libraries that use RAFT comms with NCCL, not NCCL standalone tests, so we are still investigating the root cause. This fix does not seem to have any ill effects during testing and benchmarking though, so it's the fastest way to restore behavior in ARM 12.8 behaviors without needing user intervention. 