### PR TITLE
add shellcheck, update pre-commit hooks

### DIFF
--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
 name: Build and push image variant
 
 on:

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
 name: Build and push image variant
 
 on:

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -46,12 +46,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit run --all-files
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@v3.0.1
   compute-matrix:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 name: build and publish imgs workflow
 
 on:

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -47,7 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
   compute-matrix:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 name: ci
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 name: publish
 
 on:

--- a/.github/workflows/release-to-ngc.yml
+++ b/.github/workflows/release-to-ngc.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 name: Publish release images to NGC
 
 on:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 name: Test notebooks
 
 on:

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 name: Trigger Breaking Change Notifications
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -19,3 +20,7 @@ repos:
     rev: v0.6.0
     hooks:
       - id: verify-copyright
+        files: |
+          (?x)
+              [.](jq|py|sh|toml|yml|yaml)$|
+              Dockerfile$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,21 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.9.9
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v0.6.0
+    hooks:
+      - id: verify-copyright

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 ARG CUDA_VER=unset
 ARG PYTHON_VER=unset

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -eEuo pipefail
 

--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+
 def compute_arch($x):
   $x + {ARCHES: ["amd64", "arm64"]};
 

--- a/ci/compute-matrix.sh
+++ b/ci/compute-matrix.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/create-cuvs-multiarch-manifest.sh
+++ b/ci/create-cuvs-multiarch-manifest.sh
@@ -38,6 +38,8 @@ done
 docker manifest create "${org}/${CUVS_BENCH_IMAGE_REPO}:${cuvs_bench_tag}" "${cuvs_bench_source_tags[@]}"
 docker manifest push "${org}/${CUVS_BENCH_IMAGE_REPO}:${cuvs_bench_tag}"
 
+# this and everything above that it uses can be uncommented once the issues with cuVS datasets are fixed
+# ref: https://github.com/rapidsai/docker/issues/724
 # docker manifest create "${org}/${CUVS_BENCH_DATASETS_IMAGE_REPO}:${cuvs_bench_datasets_tag}" "${cuvs_bench_datasets_source_tags[@]}"
 # docker manifest push "${org}/${CUVS_BENCH_DATASETS_IMAGE_REPO}:${cuvs_bench_datasets_tag}"
 

--- a/ci/create-cuvs-multiarch-manifest.sh
+++ b/ci/create-cuvs-multiarch-manifest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
 set -eEuo pipefail
 
 common_path="$(dirname "$(realpath "$0")")/common.sh"
@@ -7,18 +9,18 @@ common_path="$(dirname "$(realpath "$0")")/common.sh"
 source "$common_path"
 
 cuvs_bench_source_tags=()
-cuvs_bench_datasets_source_tags=()
+# cuvs_bench_datasets_source_tags=()
 cuvs_bench_cpu_source_tags=()
 
 # Define tag arrays for different images
 cuvs_bench_tag="${CUVS_BENCH_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
-cuvs_bench_datasets_tag="${CUVS_BENCH_DATASETS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
+# cuvs_bench_datasets_tag="${CUVS_BENCH_DATASETS_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-cuda${CUDA_TAG}-py${PYTHON_VER}"
 cuvs_bench_cpu_tag="${CUVS_BENCH_CPU_TAG_PREFIX}${RAPIDS_VER}${ALPHA_TAG}-py${PYTHON_VER}"
 
 # Check if all source tags exist and add to source tags array
 for arch in $(echo "${ARCHES}" | jq .[] -r); do
     full_cuvs_bench_tag="${cuvs_bench_tag}-${arch}"
-    full_cuvs_bench_datasets_tag="${cuvs_bench_datasets_tag}-${arch}"
+    # full_cuvs_bench_datasets_tag="${cuvs_bench_datasets_tag}-${arch}"
     full_cuvs_bench_cpu_tag="${cuvs_bench_cpu_tag}-${arch}"
 
     check_tag_exists "$CUVS_BENCH_IMAGE_REPO" "$full_cuvs_bench_tag"

--- a/ci/create-cuvs-multiarch-manifest.sh
+++ b/ci/create-cuvs-multiarch-manifest.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright (c) 2025, NVIDIA CORPORATION.
 
 set -eEuo pipefail

--- a/ci/create-rapids-multiarch-manifest.sh
+++ b/ci/create-rapids-multiarch-manifest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
 
 set -eEuo pipefail
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+
 ## Usage
 # bash update-version.sh <new_version>
 
@@ -9,10 +11,6 @@ NEXT_FULL_TAG=$1
 
 # Get current version
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
-CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
-CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
-CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
 
 # Get <major>.<minor> for next version
 NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
@@ -26,7 +24,7 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-for FILE in $(find . -name Dockerfile); do
+find . -name Dockerfile | while IFS= read -r -d '' FILE; do
   sed_runner "s/ARG RAPIDS_VER=.*/ARG RAPIDS_VER=${NEXT_SHORT_TAG}/g" "${FILE}"
 done
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 ## Usage

--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -eo pipefail

--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -35,6 +35,8 @@ fi
 
 # Run whatever the user wants.
 if [ "${UNQUOTE}" = "true" ]; then
+    # splitting elements without quoting is intentional here,
+    # to make it possible to tightly control the quoting of arguments
     # shellcheck disable=SC2068
     exec $@
 else

--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+
 set -eo pipefail
 
 cat << EOF
@@ -33,6 +36,7 @@ fi
 
 # Run whatever the user wants.
 if [ "${UNQUOTE}" = "true" ]; then
+    # shellcheck disable=SC2068
     exec $@
 else
     exec "$@"

--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 # Clones repos with notebooks & compiles notebook test dependencies
 # Requires environment variables:

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 import argparse

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+
 import argparse
 import os
 import sys
@@ -197,7 +199,7 @@ if __name__ == "__main__":
 
     if found_errors:
         print("Error during notebook tests!")
-        for notebook in nb_errors.keys():
-            if nb_errors[notebook]:
-                print(f'Errors during {notebook}')
+        for notebook_id, errors in nb_errors.items():
+            if errors:
+                print(f"Errors during '{notebook_id}'")
         sys.exit(2)

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -37,6 +37,8 @@ ignored_notebooks = [
     'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
     # context on this being skipped: https://github.com/rapidsai/docker/issues/726
     'cuspatial/trajectory_clustering.ipynb',
+    # context on this being skipped: https://github.com/rapidsai/docker/issues/740
+    'cuspatial/Taxi_Dropoff_Reverse_Geocoding.ipynb',
 ]
 
 

--- a/cuvs-bench/cpu/Dockerfile
+++ b/cuvs-bench/cpu/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 ARG PYTHON_VER=unset
 ARG RAPIDS_VER=25.04

--- a/cuvs-bench/gpu/Dockerfile
+++ b/cuvs-bench/gpu/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 ARG CUDA_VER=unset
 ARG PYTHON_VER=unset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+
 [tool.ruff]
 target-version = "py310"
 


### PR DESCRIPTION
Contributes to #667

Expands testing to improve release confidence in these images.

* adds new `pre-commit` hooks:
  - `rapidsai/verify-copyright` = keep copyright notices up to date
  - `shellcheck` = catch issues and enforce consistency in shell scripts
* updates all other `pre-commit` hooks
* switches from a manual `run:` to `pre-commit/action@v3.0.1` in CI, for faster runs of `pre-commit` and simpler CI configuration



