### PR TITLE
Remove cuSpatial notebooks

### DIFF
--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-NOTEBOOK_REPOS=(cudf cuml cugraph cuspatial)
+NOTEBOOK_REPOS=(cudf cuml cugraph)
 
 mkdir -p /notebooks /dependencies
 for REPO in "${NOTEBOOK_REPOS[@]}"; do

--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -21,21 +21,7 @@ ignored_subdirectory_names = [
     "demo",
 ]
 ignored_filenames = ["-csv", "benchmark", "target", "performance"]
-ignored_notebooks = [
-    'cusignal/api_guide/io_examples.ipynb', # 26gb data download
-
-    # following nbs are marked as skipped
-    'cugraph/algorithms/layout/Force-Atlas2.ipynb',
-    'cuspatial/binary_predicates.ipynb',
-    'cuspatial/cuproj_benchmark.ipynb',
-    # context on these being skipped: https://github.com/rapidsai/cuspatial/pull/1407
-    'cuspatial/cuspatial_api_examples.ipynb',
-    'cuspatial/nyc_taxi_years_correlation.ipynb',
-    # context on skip zipcodes: https://github.com/rapidsai/cuspatial/issues/1426
-    'cuspatial/ZipCodes_Stops_PiP_cuSpatial.ipynb',
-    # context on this being skipped: https://github.com/rapidsai/docker/issues/726
-    'cuspatial/trajectory_clustering.ipynb',
-]
+ignored_notebooks = []
 
 
 def get_notebooks(directory: str) -> Iterable[str]:


### PR DESCRIPTION
This PR removes cuSpatial notebooks from the notebook container. Most of these notebooks are unsupported for various reasons, so this ensures the notebook container ships examples that are widely supported.
