### PR TITLE
lint Dockerfiles with 'hadolint'

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -50,6 +50,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
+      - name: Run hadolint
+        run: |
+          ci/lint-dockerfiles.sh
   compute-matrix:
     runs-on: ubuntu-latest
     container:

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 
 ignored:
-  # warning: Using latest is prone to errors if the image will ever update
-  #- DL3007
   # warning: Pin versions in apt get install.
   - DL3008
   # warning: Pin versions in pip.

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+ignored:
+  # warning: Using latest is prone to errors if the image will ever update
+  #- DL3007
+  # warning: Pin versions in apt get install.
+  - DL3008
+  # warning: Pin versions in pip.
+  - DL3013
+  # warning: Avoid use of cache directory with pip.
+  - DL3042

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.6
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ ARG LINUX_VER=${LINUX_DISTRO}${LINUX_DISTRO_VER}
 ARG RAPIDS_VER=25.06
 
 # Gather dependency information
+
+# ignore hadolint DL3007... we really do always want the latest 'rapidsai/ci-conda',
+# and don't want to have to push new commits to update to it
+#
+# hadolint ignore=DL3007
 FROM rapidsai/ci-conda:latest AS dependencies
 ARG CUDA_VER
 ARG PYTHON_VER
@@ -27,7 +32,7 @@ COPY notebooks.sh /notebooks.sh
 
 RUN <<EOF
 apt-get update
-apt-get install -y rsync
+apt-get install -y --no-install-recommends rsync
 /notebooks.sh
 apt-get purge -y --auto-remove rsync
 rm -rf /var/lib/apt/lists/*
@@ -45,11 +50,12 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN <<EOF
 apt-get update
-apt-get install -y wget
-wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
+apt-get install -y --no-install-recommends wget
+wget --quiet https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
 apt-get purge -y --auto-remove wget
 rm -rf /var/lib/apt/lists/*
 EOF
+
 RUN useradd -rm -d /home/rapids -s /bin/bash -g conda -u 1001 rapids
 
 USER rapids

--- a/ci/lint-dockerfiles.sh
+++ b/ci/lint-dockerfiles.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+set -u -o pipefail
+
+# only exit at the very end, instead of on the first failed check
+EXIT_CODE=0
+trap "EXIT_CODE=1" ERR
+set +e
+
+DOCKERFILES=$(find . -type f -name 'Dockerfile')
+
+for dockerfile in ${DOCKERFILES}; do
+	echo "linting '${dockerfile}'"
+	docker run \
+		--rm \
+        -v "$(pwd)/.hadolint.yaml":/.config/hadolint.yaml \
+		-i \
+		hadolint/hadolint \
+	< "${dockerfile}"
+done
+
+echo "done checking images with 'hadolint'. Exiting (exit code = ${EXIT_CODE})."
+exit ${EXIT_CODE}

--- a/cuvs-bench/cpu/Dockerfile
+++ b/cuvs-bench/cpu/Dockerfile
@@ -24,10 +24,10 @@ EOF
 # we need perl temporarily for the remaining benchmark perl scripts
 RUN <<EOF
 apt-get update
-apt-get install -y \
+apt-get install -y --no-install-recommends \
   perl \
   wget
-wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
+wget --quiet https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
 rm -rf /var/lib/apt/lists/*
 EOF
 
@@ -55,8 +55,7 @@ CMD ["--dataset fashion-mnist-784-euclidean", "", "--algorithms hnswlib"]
 
 ENTRYPOINT ["/bin/bash", "/data/scripts/run_benchmark.sh"]
 
-
-FROM bench-base AS cuvs-bench-cpu-datasets
+FROM cuvs-bench-cpu AS cuvs-bench-cpu-datasets
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/cuvs-bench/gpu/Dockerfile
+++ b/cuvs-bench/gpu/Dockerfile
@@ -27,10 +27,10 @@ EOF
 # we need perl temporarily for the remaining benchmark perl scripts
 RUN <<EOF
 apt-get update
-apt-get install -y \
+apt-get install -y --no-install-recommends \
   perl \
   wget
-wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
+wget --quiet https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
 rm -rf /var/lib/apt/lists/*
 EOF
 


### PR DESCRIPTION
Contributes to #667

Proposes running `hadolint` (https://github.com/hadolint/hadolint) on Dockerfiles in this repo. I've found that this tool makes some of the same recommendations that I find myself making in PR reviews... I hope enforcing it in CI will reduce reviewing effort a bit and improve our release confidence.

All the Dockerfiles contain changes for these reported issues, which I agree with:

```text
DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`. Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
```

See other comments inline.

## Notes for Reviewers

### Why not use `pre-commit`?

As @KyleFromNVIDIA pointed out to me a while ago, the install hooks for `hadolint`'s `pre-commit` hook are broken: https://github.com/hadolint/hadolint/issues/886

We don't change these Dockefiles **that** often... I think the slight extra friction of having to run a script manually or just get feedback from CI should not block us from adopting this tool.