### PR TITLE
remove ANSI escape sequences in notebook tracebacks

### DIFF
--- a/context/test_notebooks.py
+++ b/context/test_notebooks.py
@@ -7,6 +7,7 @@ import sys
 import timeit
 from typing import Iterable
 import nbformat
+from nbconvert.filters.ansi import strip_ansi
 from nbconvert.preprocessors import ExecutePreprocessor
 import yaml
 
@@ -112,13 +113,15 @@ def test_notebook(notebook_file, executed_nb_file):
                     else:
                         outputs.append(str(ec) + "\n" + str(output["data"]))
                 elif output["output_type"] == "error":
+                    err_name = str(output["ename"])
+                    traceback_str = "\n".join(strip_ansi(line) for line in output["traceback"])
                     errors.append(
                         [
-                            str(output["ename"]),
-                            str(ec + 1) + "\n" + str(output["traceback"]),
+                            err_name,
+                            str(ec + 1) + "\n" + traceback_str,
                         ]
                     )
-                    print(str(output["ename"]), str(output["traceback"]))
+                    print(err_name, traceback_str)
                 else:
                     print(f'Unknown output type: {output["output_type"]}')
 


### PR DESCRIPTION
Fixes #741

Remove ANSI escape sequences like `\x1b[0;31m` from tracebacks printed when reporting notebook failures, to reduce the effort required to investigate those issues. See #741 for more details.

## Notes for Reviewers

### How I tested this

Luckily (😅) I opened this at at time when we had ongoing notebook failures, so could see a traceback. Looks pretty good to me!

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/f6becd79-5e00-466c-b8ee-c4e83c82c1ef" />

([build link](https://github.com/rapidsai/docker/actions/runs/14575734472/job/40882194854?pr=748))

<details><summary>text of logs (click me)</summary>

```text
Testing cuml/forest_inference_demo.ipynb
TypeError ---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], line 1
----> 1 fil_model = ForestInference.load(
      2     filename=model_path,
      3     algo='BATCH_TREE_REORG',
      4     output_class=True,
      5     threshold=0.50,
      6     model_type='xgboost_ubj'
      7 )

File fil.pyx:693, in cuml.experimental.fil.fil.ForestInference.load()

TypeError: load() takes exactly 2 positional arguments (1 given)
NameError ---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
File <timed exec>:2

NameError: name 'fil_model' is not defined
NameError ---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Cell In[11], line 2
      1 print("The shape of predictions obtained from xgboost : ", (trained_model_preds).shape)
----> 2 print("The shape of predictions obtained from FIL : ", (fil_preds).shape)
      3 print("Are the predictions for xgboost and FIL the same : ",  cupy.allclose(trained_model_preds, fil_preds))

NameError: name 'fil_preds' is not defined
TypeError ---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File <timed eval>:1

File /opt/conda/lib/python3.10/site-packages/distributed/client.py:3[192](https://github.com/rapidsai/docker/actions/runs/14575734472/job/40882194854?pr=748#step:9:193), in Client.run(self, function, workers, wait, nanny, on_error, *args, **kwargs)
   3109 def run(
   3110     self,
   3111     function,
   (...)
   3117     **kwargs,
    669         scheduler=scheduler,
    670         get=get,
    671         **kwargs,
    672     )

File /opt/conda/lib/python3.10/site-packages/dask/base.py:662, in compute(traverse, optimize_graph, scheduler, get, *args, **kwargs)
    659     postcomputes.append(x.__dask_postcompute__())
    661 with shorten_traceback():
--> 662     results = schedule(dsk, keys, **kwargs)
    664 return repack([f(r, *a) for r, (f, a) in zip(results, postcomputes)])

Cell In[20], line 3, in predict()
      1 def predict(input_df):
      2    worker = get_worker()
----> 3    return worker.data["fil_model"].predict(input_df)

File /opt/conda/lib/python3.10/site-packages/dask_cuda/device_host_file.py:273, in __getitem__()
    271 elif key in self.host_buffer:
    272     return self.host_buffer[key]
--> 273 raise KeyError(key)

KeyError: 'fil_model'
NameError ---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Cell In[23], line 2
      1 total_samples = len(df)
----> 2 print(f' {total_samples:,} inferences in {fil_inference_time:.5f} seconds'
      3       f' -- {int(total_samples/fil_inference_time):,} inferences per second ')

NameError: name 'fil_inference_time' is not defined
```

</details>

