### PR TITLE
Install curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,8 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends wget
-wget --quiet https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin
-apt-get purge -y --auto-remove wget
+apt-get install -y --no-install-recommends curl
+curl --silent --show-errors -L https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz | tar -xz -C /usr/local/bin
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends curl
-curl --silent --show-errors -L https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz | tar -xz -C /usr/local/bin
+curl --silent --show-error -L https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz | tar -xz -C /usr/local/bin
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/tests/container-canary/base.yml
+++ b/tests/container-canary/base.yml
@@ -39,6 +39,14 @@ checks:
           - -m
           - distributed.cli.dask_spec
           - --version
+  # ref: https://github.com/rapidsai/docker/pull/750
+  - name: tool-curl
+    description: curl can be executed
+    probe:
+      exec:
+        command:
+          - curl
+          - --version
   - name: user-is-rapids
     description: Default user is rapids (uid=1001)
     probe:


### PR DESCRIPTION
Some users utilize curl across many images to perform healthchecks. In `25.04`, the `cuspatial` notebooks were dropped which also dropped the image's dependency on `curl`.

So this PR explicitly installs the `curl` system package. And just to simplify things, switches to use `curl` to download instead of `wget`.