### PR TITLE
Publish to ngc nvstaging

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,4 +1,5 @@
 # Configuration file for `copy-pr-bot` GitHub App
 # https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 enabled: true

--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,5 +1,6 @@
 # This file controls which features from the `ops-bot` repository below are enabled.
 # - https://github.com/rapidsai/ops-bot
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 auto_merger: true
 branch_checker: true

--- a/.github/workflows/release-to-nvstaging.yml
+++ b/.github/workflows/release-to-nvstaging.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION.
+
 name: Publish release images to NGC
 
 on:
@@ -58,7 +59,7 @@ jobs:
 
           for type in base notebooks; do
             source="rapidsai/$type:${{ inputs.RAPIDS_VER }}-cuda$CUDA_VER_SHORT-py$PYTHON_VER"
-            target="nvcr.io/nvidia/rapidsai/$type:${{ inputs.RAPIDS_VER }}-cuda$CUDA_VER_SHORT-py$PYTHON_VER"
+            target="nvcr.io/nvstaging/rapids/$type:${{ inputs.RAPIDS_VER }}-cuda$CUDA_VER_SHORT-py$PYTHON_VER"
             echo "$source => $target"
             docker run -v ~/.docker/config.json:/config.json quay.io/skopeo/stable:latest copy --multi-arch all --dest-authfile=/config.json docker://$source docker://$target
           done

--- a/context/cuvs-bench/get_datasets.sh
+++ b/context/cuvs-bench/get_datasets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -eo pipefail
 

--- a/context/cuvs-bench/run_benchmark.sh
+++ b/context/cuvs-bench/run_benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -eo pipefail
 

--- a/context/cuvs-bench/run_benchmarks_preloaded_datasets.sh
+++ b/context/cuvs-bench/run_benchmarks_preloaded_datasets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -eo pipefail
 

--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # CUDA_VER is `<major>.<minor>` (e.g. `12.0`)
 
 pull-request:

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+
 CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `12.8.0`)
   - "11.8.0"
   - "12.0.1"


### PR DESCRIPTION
Modifies the previous `publish-to-ngc` workflow to publish to nvstaging instead.

A [second PR](https://github.com/rapidsai/release-scripts/pull/27) has been opened to add changes to copy the images published by this workflow to NGC public catalog.