### PR TITLE
add git and wget to images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.10
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,10 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends curl
+apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    wget
 curl --silent --show-error -L https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz | tar -xz -C /usr/local/bin
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/tests/container-canary/base.yml
+++ b/tests/container-canary/base.yml
@@ -47,6 +47,24 @@ checks:
         command:
           - curl
           - --version
+  # some use-cases with these images expect 'git' to be present,
+  # e.g. to clone repos in startup scripts
+  - name: tool-git
+    description: git can be executed
+    probe:
+      exec:
+        command:
+          - git
+          - --version
+  # some use-cases with these images expect 'wget' to be present,
+  # e.g. to download datasets
+  - name: tool-wget
+    description: wget can be executed
+    probe:
+      exec:
+        command:
+          - wget
+          - --version
   - name: user-is-rapids
     description: Default user is rapids (uid=1001)
     probe:


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ops/issues/4001 (private issue, sorry).

Closes #757

Adds `git` and `wget` to the images. Per @taureandyernv , those tools are so often used in workflows involving these images that it's worth the small additional image size for the convenience of having them pre-installed.

Changes:

* adds `git` and `wget` to the `rapidsai/base` and `rapidsai/notebooks` images
* adds `container-canary` tests to ensure they aren't accidentally removed in the future
* pulls in changes from `pre-commit autoupdate`, to avoid a separate CI run for #757 (since we're making changes here anyway, figured we might as well combine these small updates)