### PR TITLE
Add compilers to base & notebooks images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ rapids-mamba-retry install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "python=${PYTHON_VER}.*" \
     "cuda-version=${CUDA_VER%.*}.*" \
+    compilers \
     ipython
 conda clean -afy
 EOF

--- a/tests/container-canary/base.yml
+++ b/tests/container-canary/base.yml
@@ -65,6 +65,29 @@ checks:
         command:
           - wget
           - --version
+  # some use-cases install new packages using 'pip', requiring a build
+  # So check that compilers are available
+  - name: tool-gcc
+    description: gcc can be executed
+    probe:
+      exec:
+        command:
+          - gcc
+          - --version
+  - name: tool-g++
+    description: g++ can be executed
+    probe:
+      exec:
+        command:
+          - g++
+          - --version
+  - name: tool-gfortran
+    description: gfortran can be executed
+    probe:
+      exec:
+        command:
+          - gfortran
+          - --version
   - name: user-is-rapids
     description: Default user is rapids (uid=1001)
     probe:

--- a/tests/container-canary/notebooks.yml
+++ b/tests/container-canary/notebooks.yml
@@ -15,3 +15,26 @@ checks:
           - jupyter
           - lab
           - --version
+  # some use-cases install new packages using 'pip', requiring a build
+  # So check that compilers are available
+  - name: tool-gcc
+    description: gcc can be executed
+    probe:
+      exec:
+        command:
+          - gcc
+          - --version
+  - name: tool-g++
+    description: g++ can be executed
+    probe:
+      exec:
+        command:
+          - g++
+          - --version
+  - name: tool-gfortran
+    description: gfortran can be executed
+    probe:
+      exec:
+        command:
+          - gfortran
+          - --version


### PR DESCRIPTION
Some use cases of these images install a few pip packages which require building. So this PR ensures that the compilers are available.