### PR TITLE
add rapids-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ rapids-mamba-retry install -y -n base \
     "rapids=${RAPIDS_VER}.*" \
     "python=${PYTHON_VER}.*" \
     "cuda-version=${CUDA_VER%.*}.*" \
-    ipython
+    ipython \
+    'rapids-cli==0.1.*'
 conda clean -afy
 EOF
 

--- a/tests/container-canary/base.yml
+++ b/tests/container-canary/base.yml
@@ -56,6 +56,16 @@ checks:
         command:
           - git
           - --version
+  # some use-cases with these images expect 'git' to be present,
+  # e.g. to clone repos in startup scripts
+  - name: tool-rapids-cli
+    description: rapids doctor should work
+    probe:
+      exec:
+        command:
+          - rapids
+          - doctor
+          - --help
   # some use-cases with these images expect 'wget' to be present,
   # e.g. to download datasets
   - name: tool-wget


### PR DESCRIPTION
Adds `rapids-cli` to the RAPIDS images.

This is the first release of RAPIDS to include `rapids-cli`. For details, see https://github.com/rapidsai/rapids-cli.