### PR TITLE
use docker cache, run pre-commit updates less frequently

### DIFF
--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -81,6 +81,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
+          # Using the built-in config from NVIDIA's self-hosted runners means that 'docker build'
+          # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,
+          # fewer network failures, and fewer rate-limiting issues
+          buildkitd-config: /etc/buildkit/buildkitd.toml
           driver: docker
           endpoint: builders
       - name: Build cuVS Benchmarks GPU image

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -75,6 +75,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
+          # Using the built-in config from NVIDIA's self-hosted runners means that 'docker build'
+          # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,
+          # fewer network failures, and fewer rate-limiting issues
+          buildkitd-config: /etc/buildkit/buildkitd.toml
           driver: docker
           endpoint: builders
       - name: Build base image

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 ---
+ci:
+  autoupdate_schedule: 'monthly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -7,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
@@ -17,7 +19,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.6.0
+    rev: v0.7.0
     hooks:
       - id: verify-copyright
         files: |


### PR DESCRIPTION
Replaces #770

Proposes 2 small changes to help with development here:

* using the DockerHub pull-through cache on NVIDIA's self-hosted runners
  - *to reduce the disruption from network issues and rate limits (see https://github.com/rapidsai/ci-imgs/pull/281#issuecomment-3001418760)*
* switching the `pre-commit.ci` autoupdates from weekly to monthly
  - *this project uses some tools like `ruff` that update very frequently, meaning we get a new PR from `pre-commit.ci` almost every week... CI here uses a LOT of runners, and for this repo I don't think that resource usage is worth it in exchange for moving to a new version of `ruff` a few weeks earlier than we otherwise would*