### PR TITLE
Test earliest driver with CUDA 12.9

### DIFF
--- a/matrix-test.yaml
+++ b/matrix-test.yaml
@@ -2,9 +2,9 @@
 # CUDA_VER is `<major>.<minor>` (e.g. `12.0`)
 
 pull-request:
-  - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'earliest' }
-  - { CUDA_VER: '12.9', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'latest'   }
-  - { CUDA_VER: '12.9', ARCH: 'amd64', PYTHON_VER: '3.13', GPU: 'l4',   DRIVER: 'latest'   }
+  - { CUDA_VER: '12.9', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'earliest' }
+  - { CUDA_VER: '12.9', ARCH: 'arm64', PYTHON_VER: '3.11', GPU: 'a100', DRIVER: 'earliest' }
+  - { CUDA_VER: '12.9', ARCH: 'amd64', PYTHON_VER: '3.13', GPU: 'l4',   DRIVER: 'earliest' }
 branch:
   - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'earliest' }
   - { CUDA_VER: '12.0', ARCH: 'amd64', PYTHON_VER: '3.10', GPU: 'l4',   DRIVER: 'latest'   }

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `12.9.0`)
-  - "12.0.1"
   - "12.9.1"
 PYTHON_VER:
   - "3.10"


### PR DESCRIPTION
Test PR to see if our CUDA 12.9 containers work on driver 535 (LTS branch, so should be supported).
