### PR TITLE
include XGBoost CUDA packages in CUDA 13 images

### DIFF
--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -9,13 +9,7 @@
 
 set -euo pipefail
 
-# TODO: restore cuml notebook testing on CUDA 13 once there are CUDA 13 xgboost packages and 'rapids' depends on them
-#  ref: https://github.com/rapidsai/integration/issues/798
-if [[ "${CUDA_VER%%.*}" == "12" ]]; then
-    NOTEBOOK_REPOS=(cudf cuml cugraph)
-else
-    NOTEBOOK_REPOS=(cudf cugraph)
-fi
+NOTEBOOK_REPOS=(cudf cuml cugraph)
 
 mkdir -p /notebooks /dependencies
 for REPO in "${NOTEBOOK_REPOS[@]}"; do


### PR DESCRIPTION
Closes #784 

In #782, we skipped cuML notebook testing on CUDA 13 because there weren't yet CUDA 13 `xgboost` conda packages. Those exist now:

* https://github.com/rapidsai/xgboost-feedstock/issues/100
* https://github.com/rapidsai/integration/pull/800

This reverts a workaround from #782, so all notebooks will be tested on CUDA 12 and CUDA 13. It also ensures that the CUDA 13 images include GPU-accelerated builds of `xgboost`.