### PR TITLE
update CUDA 13 images to 13.0.1

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
-CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `13.0.0`)
+CUDA_VER: # Should be `<major>.<minor>.<patch>` (e.g. `13.0.1`)
   - "12.0.1"
   - "12.9.1"
-  - "13.0.0"
+  - "13.0.1"
 PYTHON_VER:
   - "3.10"
   - "3.11"


### PR DESCRIPTION
RAPIDS recently started building and testing against CUDA 13.0.1:

* https://github.com/rapidsai/ci-imgs/pull/304
* https://github.com/rapidsai/shared-workflows/pull/423

This updates the images here from 13.0.0 to 13.0.1.

## Notes for Reviewers

Hopefully those types of differences will go away soon, with #781