### PR TITLE
Fix docs to reference CUDA major version tags

### DIFF
--- a/cuvs-bench/README.md
+++ b/cuvs-bench/README.md
@@ -36,7 +36,7 @@ export DATA_FOLDER=path/to/store/results/and/data
 docker run --gpus all --rm -it \
     -v $DATA_FOLDER:/home/rapids/benchmarks \
     -u $(id -u) \
-    rapidsai/cuvs-bench:25.12a-cuda13.0-py3.13 \
+    rapidsai/cuvs-bench:25.12a-cuda13-py3.13 \
     "--dataset deep-image-96-angular" \
     "--normalize" \
     "--algorithms cuvs_cagra" \
@@ -47,7 +47,7 @@ Where:
 
 - `DATA_FOLDER=path/to/store/results/and/data`: Results and datasets will be written to this host folder.
 - `-u $(id -u)`: This flag allows the container to use the host user for permissions
-- `rapidsai/cuvs-bench:25.12a-cuda13.0-py3.13`: Image to use, either `cuvs-bench` or `cuvs-bench-datasets`, cuVS version, CUDA version, and Python version.
+- `rapidsai/cuvs-bench:25.12a-cuda13-py3.13`: Image to use, either `cuvs-bench` or `cuvs-bench-datasets`, cuVS version, CUDA version, and Python version.
 - "--dataset deep-image-96-angular": Dataset name(s). See https://docs.rapids.ai/api/cuvs/nightly/cuvs_bench for more details.
 - "--normalize": Whether to normalize the dataset, leave string empty ("") to not normalize.
 - "--algorithms cuvs_cagra": What algorithm(s) to use as a ; separated list, as well as any other argument to pass to `cuvs_bench.run`.
@@ -74,7 +74,7 @@ export DATA_FOLDER=path/to/store/results/and/data
 docker run --gpus all --rm -it \
     -v $DATA_FOLDER:/home/rapids/benchmarks \
     -u $(id -u) \
-    rapidsai/cuvs-bench:25.12a-cuda13.0-py3.13 \
+    rapidsai/cuvs-bench:25.12a-cuda13-py3.13 \
     --entrypoint /bin/bash
 ```
 

--- a/dockerhub-readme.md
+++ b/dockerhub-readme.md
@@ -85,7 +85,7 @@ $ docker run \
     -e EXTRA_CONDA_PACKAGES="jq" \
     -e EXTRA_PIP_PACKAGES="beautifulsoup4" \
     -p 8888:8888 \
-    rapidsai/notebooks:25.12-cuda13.0-py3.13
+    rapidsai/notebooks:25.12-cuda13-py3.13
 ```
 
 ### Bind Mounts
@@ -110,7 +110,7 @@ $ docker run \
     --gpus all \
     --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
     -v $(pwd)/environment.yml:/home/rapids/environment.yml \
-    rapidsai/base:25.12-cuda13.0-py3.13
+    rapidsai/base:25.12-cuda13-py3.13
 ```
 
 ### Use JupyterLab to Explore the Notebooks

--- a/tests/container-canary/README.md
+++ b/tests/container-canary/README.md
@@ -9,7 +9,7 @@ Install `container-canary` following the instructions in that project's repo.
 Run the tests against a built image, the same way they're run in CI.
 
 ```shell
-IMAGE_URI="rapidsai/notebooks:25.12a-cuda13.0-py3.13"
+IMAGE_URI="rapidsai/notebooks:25.12a-cuda13-py3.13"
 
 ci/run-validation-checks.sh \
     --dask-scheduler \


### PR DESCRIPTION
I missed some documentation updates in #793. This fixes them.
