### PR TITLE
patch fix for CVE-2025-8194

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,15 @@ EOF
 
 RUN useradd -rm -d /home/rapids -s /bin/bash -g conda -u 1001 rapids
 
+### -- CVE-2025-8194 tarfile patch -- ###
+# Adjust Python version path if needed (e.g., 3.9 or 3.11)
+ENV PYTHON_SITE_PKGS=/opt/conda/lib/python${PYTHON_VER}/site-packages
+
+# Download and install the patch
+RUN curl -sSL https://gist.githubusercontent.com/sethmlarson/1716ac5b82b73dbcbf23ad2eff8b33e1/raw/tarfile_patch.py \
+      -o ${PYTHON_SITE_PKGS}/tarfile_patch.py && \
+    echo "import tarfile_patch" > ${PYTHON_SITE_PKGS}/zzz_tar_patch.pth
+
 USER rapids
 
 WORKDIR /home/rapids


### PR DESCRIPTION
Policy Evaluation Results (warn, stop - [CVE-2025-8194](https://nvd.nist.gov/vuln/detail/CVE-2025-8194) - here is a defect in the CPython “tarfile” module affecting the “TarFile” extraction and entry enumeration APIs. The tar implementation would process tar archives with negative offsets without error, resulting in an infinite loop and deadlock during the parsing of maliciously crafted tar archives. This vulnerability can be mitigated by including the following patch after importing the “tarfile” module: https://gist.github.com/sethmlarson/1716ac5b82b73dbcbf23ad2eff8b33e1.
This patch should fix this...