### PR TITLE
added brotli for fixing CVE-2025 - 6176

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ rapids-mamba-retry install -y -n base \
     "cuda-version=${CUDA_VER%.*}.*" \
     ipython \
     'rapids-cli==0.1.*' \
-    'openssl==3.5.4' \
+    'openssl==3.6.0' \
     brotli
 conda clean -afy
 EOF


### PR DESCRIPTION
to fix the following vulnerabilities | package | GHSA-2qfp-q593-8484+brotli-1.1.0 | HIGH Vulnerability found in non-os package type (python) -    | false               |
    |            |                 |         |                                  | /opt/conda/lib/python3.10/site-packages/brotli (fixed in:     |                     |
    |            |                 |         |                                  | 1.2.0)(GHSA-2qfp-q593-8484 -                                  |                     |
    |            |                 |         |                                  | https://github.com/advisories/GHSA-2qfp-q593-8484)  