### PR TITLE
updated update-version.sh to handle release branch version changes

### DIFF
--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -43,7 +43,7 @@ jobs:
       - build-cuvs-multiarch-manifest
       - test
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.12
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
   checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -13,7 +13,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@branch-25.12
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG PYTHON_VER
 
 ARG RAPIDS_VER
 
-ARG RAPIDS_BRANCH="branch-${RAPIDS_VER}"
+ARG RAPIDS_BRANCH="main"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -2,11 +2,69 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 ## Usage
-# bash update-version.sh <new_version>
+# Primary interface:   bash update-version.sh <new_version> [--run-context=main|release]
+# Fallback interface:  [RAPIDS_RUN_CONTEXT=main|release] bash update-version.sh <new_version>
+# CLI arguments take precedence over environment variables
+# Defaults to main when no run-context is specified
 
+set -euo pipefail
+
+# Verify we're running from the repository root
+if [[ ! -d ".git" ]]; then
+    echo "Error: This script must be run from the repository root directory."
+    echo "Expected to find: .git/"
+    echo "Current directory: $(pwd)"
+    exit 1
+fi
+
+# Parse command line arguments
+CLI_RUN_CONTEXT=""
+VERSION_ARG=""
+
+for arg in "$@"; do
+    case $arg in
+        --run-context=*)
+            CLI_RUN_CONTEXT="${arg#*=}"
+            shift
+            ;;
+        *)
+            if [[ -z "$VERSION_ARG" ]]; then
+                VERSION_ARG="$arg"
+            fi
+            ;;
+    esac
+done
 
 # Format is YY.MM.PP - no leading 'v' or trailing 'a'
-NEXT_FULL_TAG=$1
+NEXT_FULL_TAG="$VERSION_ARG"
+
+# Determine RUN_CONTEXT with CLI precedence over environment variable, defaulting to main
+if [[ -n "$CLI_RUN_CONTEXT" ]]; then
+    RUN_CONTEXT="$CLI_RUN_CONTEXT"
+    echo "Using run-context from CLI: $RUN_CONTEXT"
+elif [[ -n "${RAPIDS_RUN_CONTEXT}" ]]; then
+    RUN_CONTEXT="$RAPIDS_RUN_CONTEXT"
+    echo "Using run-context from environment: $RUN_CONTEXT"
+else
+    RUN_CONTEXT="main"
+    echo "No run-context provided, defaulting to: $RUN_CONTEXT"
+fi
+
+# Validate RUN_CONTEXT value
+if [[ "${RUN_CONTEXT}" != "main" && "${RUN_CONTEXT}" != "release" ]]; then
+    echo "Error: Invalid run-context value '${RUN_CONTEXT}'"
+    echo "Valid values: main, release"
+    exit 1
+fi
+
+# Validate version argument
+if [[ -z "$NEXT_FULL_TAG" ]]; then
+    echo "Error: Version argument is required"
+    echo "Usage: $0 <new_version> [--run-context=<context>]"
+    echo "   or: [RAPIDS_RUN_CONTEXT=<context>] $0 <new_version>"
+    echo "Note: Defaults to main when run-context is not specified"
+    exit 1
+fi
 
 # Get current version
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
@@ -16,7 +74,16 @@ NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
 NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
-echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
+# Set branch references based on RUN_CONTEXT
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    RAPIDS_BRANCH_NAME="main"
+    WORKFLOW_BRANCH_REF="main"
+    echo "Preparing development branch update $CURRENT_TAG => $NEXT_FULL_TAG (targeting main branch)"
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    RAPIDS_BRANCH_NAME="release/${NEXT_SHORT_TAG}"
+    WORKFLOW_BRANCH_REF="release/${NEXT_SHORT_TAG}"
+    echo "Preparing release branch update $CURRENT_TAG => $NEXT_FULL_TAG (targeting release/${NEXT_SHORT_TAG} branch)"
+fi
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
@@ -29,9 +96,13 @@ done
 
 sed_runner "s/com\.nvidia\.workbench\.image-version=.*/com.nvidia.workbench.image-version=\"${NEXT_FULL_TAG}\"/g" Dockerfile
 
+# Dockerfile RAPIDS_BRANCH
+sed_runner "s|ARG RAPIDS_BRANCH=\"release/[0-9]\+\.[0-9]\+\"|ARG RAPIDS_BRANCH=\"${RAPIDS_BRANCH_NAME}\"|g" Dockerfile
+sed_runner "s|ARG RAPIDS_BRANCH=\"main\"|ARG RAPIDS_BRANCH=\"${RAPIDS_BRANCH_NAME}\"|g" Dockerfile
+
 # CI files
 for FILE in .github/workflows/*.yaml .github/workflows/*.yml; do
-  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "/shared-workflows/ s|@.*|@${WORKFLOW_BRANCH_REF}|g" "${FILE}"
 done
 
 sed_runner "s/v[[:digit:]]\+\.[[:digit:]]\+/v${NEXT_SHORT_TAG}/g" dockerhub-readme.md


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224