### PR TITLE
opt out of automatic attestations

### DIFF
--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -32,6 +32,13 @@ on:
         required: true
         type: boolean
 
+env:
+  # prevent buildx from creating arch-specific manifest lists...
+  # we want single images, that are later referenced together in a multiarch manifest
+  #
+  # ref: https://github.com/docker/build-push-action/issues/1339
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -32,6 +32,11 @@ on:
         required: true
         type: string
 
+env:
+  # prevent buildx from creating arch-specific manifest lists...
+  # we want single images, that are later referenced together in a multiarch manifest
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+
 jobs:
   build:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.7
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]


### PR DESCRIPTION
Closes #820

*(description copied from https://github.com/rapidsai/docker/pull/820#issuecomment-3603143732)*

`build-*-manifest` CI jobs are failing like this:

```text
docker.io/rapidsai/staging:docker-cuvs-bench-820-26.02a-cuda13-py3.10-amd64 is a manifest list
Error: Process completed with exit code 1.
```

([build link](https://github.com/rapidsai/docker/actions/runs/19864919436/job/56926457521?pr=820#step:4:23))

Looks like in newer versions of `docker`, builds create manifest lists by default instead of single image builds:

* https://github.com/NVIDIA/gpu-operator/pull/1940
* https://github.com/NVIDIA/k8s-driver-manager/pull/132
* https://github.com/docker/build-push-action/issues/1339#issuecomment-2724693651

This opts out of that using the configuration option added in https://github.com/docker/build-push-action/pull/1343

It also updates all `pre-commit` hooks, to avoid needing another CI run for #820
