### PR TITLE
renovate: group GitHub Actions updates into fewer PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,12 @@
         "^(actions/.*|aws-actions/*|docker/*|go|peter-evans/dockerhub-description|pre-commit/)$"
       ],
       "groupName": "gh-actions"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": [
+        "^condaforge/miniforge3$"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Proposes updating the `renovate` configuration so that almost all "hey there's a new version of this third-party GitHub Action" updates are grouped together into a single PR.

To avoid cases like this where multiple individual PRs are opened at the beginning of the month:

* #808
* #807
* #806

This should reduce CI usage, notifications, and review burden a bit.

## Notes for Reviewers

### How I made this list

```shell
git grep -E 'uses\: '
```

### How to test this

I'm not sure how to test this without merging it.

In https://github.com/rapidsai/ci-imgs/pull/265, we just merged a similar change and then looked at the dashboard issue to check.

So I think we should just merge this and then check https://github.com/rapidsai/docker/issues/645