### PR TITLE
ensure images only use OCI mediatypes

### DIFF
--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -92,7 +92,7 @@ jobs:
           # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,
           # fewer network failures, and fewer rate-limiting issues
           buildkitd-config: /etc/buildkit/buildkitd.toml
-          driver: docker
+          driver: docker-container
           endpoint: builders
       - name: Build cuVS Benchmarks GPU image
         uses: docker/build-push-action@v6
@@ -108,6 +108,8 @@ jobs:
             PYTHON_VER=${{ inputs.PYTHON_VER }}
             RAPIDS_VER=${{ inputs.RAPIDS_VER }}
           tags: ${{ inputs.CUVS_BENCH_TAG }}-${{ matrix.ARCH }}
+          # ensure only OCI mediatypes are used: https://docs.docker.com/build/exporters/#oci-media-types
+          outputs: type=registry,oci-mediatypes=true
       # - name: Build cuVS Benchmarks GPU with datasets image
       #   uses: docker/build-push-action@v6
       #   with:
@@ -122,6 +124,7 @@ jobs:
       #       PYTHON_VER=${{ inputs.PYTHON_VER }}
       #       RAPIDS_VER=${{ inputs.RAPIDS_VER }}
       #     tags: ${{ inputs.CUVS_BENCH_DATASETS_TAG }}-${{ matrix.ARCH }}
+      #     outputs: type=registry,oci-mediatypes=true
       - name: Build cuVS Benchmarks CPU image
         if: inputs.BUILD_CUVS_BENCH_CPU_IMAGE
         uses: docker/build-push-action@v6
@@ -137,3 +140,5 @@ jobs:
             PYTHON_VER=${{ inputs.PYTHON_VER }}
             RAPIDS_VER=${{ inputs.RAPIDS_VER }}
           tags: ${{ inputs.CUVS_BENCH_CPU_TAG }}-${{ matrix.ARCH }}
+          # ensure only OCI mediatypes are used: https://docs.docker.com/build/exporters/#oci-media-types
+          outputs: type=registry,oci-mediatypes=true

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -90,8 +90,9 @@ jobs:
           # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,
           # fewer network failures, and fewer rate-limiting issues
           buildkitd-config: /etc/buildkit/buildkitd.toml
-          driver: docker
+          driver: docker-container
           endpoint: builders
+          version: 'v0.30.1'
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
@@ -108,6 +109,8 @@ jobs:
             PYTHON_VER=${{ inputs.PYTHON_VER }}
             RAPIDS_VER=${{ inputs.RAPIDS_VER }}
           tags: ${{ inputs.BASE_TAG }}-${{ matrix.ARCH }}
+          # ensure only OCI mediatypes are used: https://docs.docker.com/build/exporters/#oci-media-types
+          outputs: type=registry,oci-mediatypes=true
       - name: Build notebooks image
         uses: docker/build-push-action@v6
         with:
@@ -124,3 +127,5 @@ jobs:
             PYTHON_VER=${{ inputs.PYTHON_VER }}
             RAPIDS_VER=${{ inputs.RAPIDS_VER }}
           tags: ${{ inputs.NOTEBOOKS_TAG }}-${{ matrix.ARCH }}
+          # ensure only OCI mediatypes are used: https://docs.docker.com/build/exporters/#oci-media-types
+          outputs: type=registry,oci-mediatypes=true


### PR DESCRIPTION
Contributes to #831 

2025.12 images from here appear to contain some non-OCI mediatypes, which is causing tools that expect OCI-compliant images to fail when processing them, which is blocking the release to NVCR.

This does the following:

* forces BuildKit to only use OCI mediatypes
* pins BuildKit to a specific version, to remove one source of change from build to build