### PR TITLE
Remove testing libraries in the `base` and `notebook` images

### DIFF
--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -29,11 +29,20 @@ for REPO in "${NOTEBOOK_REPOS[@]}"; do
         cp -rL "$SOURCE" "$DESTINATION"
     fi
 
-    if [ -f "$REPO/dependencies.yaml" ] && yq -e '.files.test_notebooks' "$REPO/dependencies.yaml" >/dev/null; then
-        echo "Running dfg on $REPO"
+    if [ -f "$REPO/dependencies.yaml" ]; then
+        # Prefer run_notebooks (runtime-only deps) over test_notebooks
+        # (which may include testing libraries like pytest).
+        if yq -e '.files.run_notebooks' "$REPO/dependencies.yaml" >/dev/null 2>&1; then
+            FILE_KEY="run_notebooks"
+        elif yq -e '.files.test_notebooks' "$REPO/dependencies.yaml" >/dev/null 2>&1; then
+            FILE_KEY="test_notebooks"
+        else
+            continue
+        fi
+        echo "Running dfg on $REPO (file-key: $FILE_KEY)"
         rapids-dependency-file-generator \
             --config "$REPO/dependencies.yaml" \
-            --file-key test_notebooks \
+            --file-key "$FILE_KEY" \
             --matrix "cuda=${CUDA_VER%.*};arch=$(arch);py=${PYTHON_VER}" \
             --output conda >"/dependencies/${REPO}_notebooks_tests_dependencies.yaml"
     fi

--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -29,23 +29,17 @@ for REPO in "${NOTEBOOK_REPOS[@]}"; do
         cp -rL "$SOURCE" "$DESTINATION"
     fi
 
-    if [ -f "$REPO/dependencies.yaml" ]; then
-        # Prefer run_notebooks (runtime-only deps) over test_notebooks
-        # (which may include testing libraries like pytest).
-        if yq -e '.files.run_notebooks' "$REPO/dependencies.yaml" >/dev/null 2>&1; then
-            FILE_KEY="run_notebooks"
-        elif yq -e '.files.test_notebooks' "$REPO/dependencies.yaml" >/dev/null 2>&1; then
-            FILE_KEY="test_notebooks"
-        else
-            continue
-        fi
-        echo "Running dfg on $REPO (file-key: $FILE_KEY)"
-        rapids-dependency-file-generator \
-            --config "$REPO/dependencies.yaml" \
-            --file-key "$FILE_KEY" \
-            --matrix "cuda=${CUDA_VER%.*};arch=$(arch);py=${PYTHON_VER}" \
-            --output conda >"/dependencies/${REPO}_notebooks_tests_dependencies.yaml"
+    if [[ "${REPO}" == "cugraph" ]]; then
+        FILE_KEY="run_notebooks"
+    else
+        FILE_KEY="test_notebooks"
     fi
+    echo "Running dfg on $REPO (file-key: $FILE_KEY)"
+    rapids-dependency-file-generator \
+        --config "$REPO/dependencies.yaml" \
+        --file-key "$FILE_KEY" \
+        --matrix "cuda=${CUDA_VER%.*};arch=$(arch);py=${PYTHON_VER}" \
+        --output conda >"/dependencies/${REPO}_notebooks_tests_dependencies.yaml"
 done
 
 pushd "/dependencies"

--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -14,11 +14,7 @@ NOTEBOOK_REPOS=(cudf cuml cugraph)
 mkdir -p /notebooks /dependencies
 for REPO in "${NOTEBOOK_REPOS[@]}"; do
     echo "Cloning $REPO..."
-    if [[ "${REPO}" == "cugraph" ]]; then
-        git clone -b split-test-libraries --depth 1 --single-branch "https://github.com/jayavenkatesh19/cugraph" "$REPO"
-    else
-        git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
-    fi
+    git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
 
     SOURCE="$REPO/notebooks"
     DESTINATION="/notebooks/$REPO"

--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -14,7 +14,11 @@ NOTEBOOK_REPOS=(cudf cuml cugraph)
 mkdir -p /notebooks /dependencies
 for REPO in "${NOTEBOOK_REPOS[@]}"; do
     echo "Cloning $REPO..."
-    git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
+    if [[ "${REPO}" == "cugraph" ]]; then
+        git clone -b split-test-libraries --depth 1 --single-branch "https://github.com/jayavenkatesh19/cugraph" "$REPO"
+    else
+        git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
+    fi
 
     SOURCE="$REPO/notebooks"
     DESTINATION="/notebooks/$REPO"

--- a/context/notebooks.sh
+++ b/context/notebooks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 
 # Clones repos with notebooks & compiles notebook test dependencies
 # Requires environment variables:
@@ -14,7 +14,11 @@ NOTEBOOK_REPOS=(cudf cuml cugraph)
 mkdir -p /notebooks /dependencies
 for REPO in "${NOTEBOOK_REPOS[@]}"; do
     echo "Cloning $REPO..."
-    git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
+    if [[ "${REPO}" == "cugraph" ]]; then
+        git clone -b split-test-libraries --depth 1 --single-branch "https://github.com/jayavenkatesh19/cugraph" "$REPO"
+    else
+        git clone -b "${RAPIDS_BRANCH}" --depth 1 --single-branch "https://github.com/rapidsai/$REPO" "$REPO"
+    fi
 
     SOURCE="$REPO/notebooks"
     DESTINATION="/notebooks/$REPO"


### PR DESCRIPTION
Towards https://github.com/rapidsai/docker/issues/835

Upstream dependency: https://github.com/rapidsai/cugraph/pull/5447 must be merged first for CI to pass for this PR.

- Updates `context/notebooks.sh` to use `run_notebooks` file-key for the cugraph `dependencies.yaml`, while keeping the `test_notebooks` key for cudf/cuml
- Adds container-canary checks verifying `pytest` libraries (regex match for conda list starting with pytest) are not installed in base or notebooks images

This removes `pytest` and other transitive dependencies from the Docker images. 

