### PR TITLE
ensure the latest tag is always used to determine version

### DIFF
--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
       - name: Clean up condarc for release builds
         run: |
-          GIT_DESCRIBE_TAG="$(git describe --tags --abbrev=0)"
+          GIT_DESCRIBE_TAG="$(git describe --tags --first-parent --abbrev=0)"
           GIT_DESCRIBE_TAG="${GIT_DESCRIBE_TAG:1}" # remove leading 'v'
           if [[ ! $GIT_DESCRIBE_TAG =~ [a-z] ]]; then
             echo 'Most recent tag is for release, adding the `rapidsai` channel and removing the `rapidsai-nightly` channel.'

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
       - name: Clean up condarc for release builds
         run: |
-          GIT_DESCRIBE_TAG="$(git describe --tags --abbrev=0)"
+          GIT_DESCRIBE_TAG="$(git describe --tags --first-parent --abbrev=0)"
           GIT_DESCRIBE_TAG="${GIT_DESCRIBE_TAG:1}" # remove leading 'v'
           if [[ ! $GIT_DESCRIBE_TAG =~ [a-z] ]]; then
             echo 'Most recent tag is for release, adding the `rapidsai` channel and removing the `rapidsai-nightly` channel.'

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Compute RAPIDS_VER
         id: compute-rapids-ver
         run: |
-          GIT_DESCRIBE_TAG="$(git describe --tags --abbrev=0)"
+          GIT_DESCRIBE_TAG="$(git describe --tags --first-parent --abbrev=0)"
           GIT_DESCRIBE_TAG="${GIT_DESCRIBE_TAG:1}" # remove leading 'v'
           ALPHA_TAG=""
           if [[ $GIT_DESCRIBE_TAG =~ [a-z] ]]; then


### PR DESCRIPTION
Nightly builds on `main` are failing like this:

```text
56.98 Could not solve for environment specs
56.98 The following packages are incompatible
56.98 ├─ rapids-dask-dependency =26.6,>=0.0.0a0 * is requested and can be installed;
56.98 └─ rapids =26.4 * is not installable because it requires
56.98    └─ custreamz =26.4 *, which requires
56.98       └─ rapids-dask-dependency =26.4 *, which conflicts with any installable versions previously reported.
```

([build link](https://github.com/rapidsai/docker/actions/runs/23732578503/job/69129525562#step:10:731))

They should be looking for 26.06 packages, and I'd expect them to because the `v26.06.00a` tag is closer to HEAD of `main` than `v26.04.00a`.

<img width="1814" height="933" alt="image" src="https://github.com/user-attachments/assets/be141f18-b937-4997-9b91-5fb0489cef51" />

I think the root cause is that I made some mistake in creating the branch for #866 (still not sure exactly what) that ended up making `v26.04.00a` satisfy this:

https://github.com/rapidsai/docker/blob/2637556074567056aa69a7cb1850ac844ef89748/.github/workflows/build-cuvs-image.yml#L63

This proposes permanently avoiding by using `git describe --first-parent`

From https://git-scm.com/docs/git-describe

> _Follow only the first parent commit upon seeing a merge commit. This is useful when you wish to not match tags on branches merged in the history of the target commit._

## Notes for Reviewers

### How I tested this

```console
$ git checkout main
$ git pull upstream main
$ git fetch upstream --tags
$ git describe --tags --abbrev=0
v26.04.00a
$ git describe --tags --first-parent --abbrev=0
v26.06.00a
```