### PR TITLE
fix: add `zizmor` and remediate all findings

### DIFF
--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Clean up condarc for release builds
         run: |
           GIT_DESCRIBE_TAG="$(git describe --tags --first-parent --abbrev=0)"

--- a/.github/workflows/build-cuvs-image.yml
+++ b/.github/workflows/build-cuvs-image.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-cpu4"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Clean up condarc for release builds
@@ -69,7 +69,7 @@ jobs:
             echo "Most recent tag is an alpha. Build will use nightly channels."
           fi
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
         run: |
           docker context create builders
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           # Using the built-in config from NVIDIA's self-hosted runners means that 'docker build'
           # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,
@@ -95,7 +95,7 @@ jobs:
           PYTHON_VER: ${{ inputs.PYTHON_VER }}
           RAPIDS_VER: ${{ inputs.RAPIDS_VER }}
       - name: Build cuVS Benchmarks GPU image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: context
           file: cuvs-bench/gpu/Dockerfile
@@ -109,7 +109,7 @@ jobs:
           outputs: type=registry,oci-mediatypes=true
       - name: Build cuVS Benchmarks CPU image
         if: inputs.BUILD_CUVS_BENCH_CPU_IMAGE
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: context
           file: cuvs-bench/cpu/Dockerfile

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Clean up condarc for release builds
         run: |
           GIT_DESCRIBE_TAG="$(git describe --tags --first-parent --abbrev=0)"

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           docker context create builders
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3 # zizmor: ignore[cache-poisoning]
         with:
           # Using the built-in config from NVIDIA's self-hosted runners means that 'docker build'
           # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,

--- a/.github/workflows/build-rapids-image.yml
+++ b/.github/workflows/build-rapids-image.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-cpu4"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Clean up condarc for release builds
@@ -70,7 +70,7 @@ jobs:
             echo "Most recent tag is an alpha. Build will use nightly channels."
           fi
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
         run: |
           docker context create builders
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           # Using the built-in config from NVIDIA's self-hosted runners means that 'docker build'
           # will use NVIDIA's self-hosted DockerHub pull-through cache, which should mean faster builds,
@@ -100,7 +100,7 @@ jobs:
           PYTHON_VER: ${{ inputs.PYTHON_VER }}
           RAPIDS_VER: ${{ inputs.RAPIDS_VER }}
       - name: Build base image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: context
           file: Dockerfile
@@ -113,7 +113,7 @@ jobs:
           # ensure only OCI mediatypes are used: https://docs.docker.com/build/exporters/#oci-media-types
           outputs: type=registry,oci-mediatypes=true
       - name: Build notebooks image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: context
           file: Dockerfile

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -43,13 +43,13 @@ jobs:
       - build-cuvs-multiarch-manifest
       - test
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main # zizmor: ignore[unpinned-uses]
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       - name: Run hadolint
         run: |
           ci/lint-dockerfiles.sh
@@ -70,7 +70,7 @@ jobs:
       ALPHA_TAG: ${{ steps.compute-rapids-ver.outputs.ALPHA_TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Compute matrix
@@ -206,11 +206,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
@@ -238,11 +238,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -42,7 +42,7 @@ jobs:
       - build-cuvs
       - build-cuvs-multiarch-manifest
       - test
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main # zizmor: ignore[unpinned-uses]
   checks:
     runs-on: ubuntu-latest
@@ -145,7 +145,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: ./.github/workflows/build-rapids-image.yml
     # Referencing something from the 'matrix' context prevents GitHub auto-generating
     # a hard-to-read name with all the matrix input values.
@@ -179,7 +179,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: ./.github/workflows/build-cuvs-image.yml
     # Referencing something from the 'matrix' context prevents GitHub auto-generating
     # a hard-to-read name with all the matrix input values.
@@ -278,7 +278,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.TEST_MATRIX) }}
       fail-fast: false
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: ./.github/workflows/validate.yml
     # Referencing something from the 'matrix' context prevents GitHub auto-generating
     # a hard-to-read name with all the matrix input values.
@@ -315,7 +315,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.TEST_MATRIX) }}
       fail-fast: false
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: ./.github/workflows/test-notebooks.yml
     # Referencing something from the 'matrix' context prevents GitHub auto-generating
     # a hard-to-read name with all the matrix input values.

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       - name: Run hadolint
@@ -73,6 +75,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Compute matrix
         id: compute-matrix
         run: |
@@ -209,6 +212,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -241,6 +245,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:

--- a/.github/workflows/build-test-publish-images.yml
+++ b/.github/workflows/build-test-publish-images.yml
@@ -83,9 +83,11 @@ jobs:
           echo "MATRIX=${MATRIX}" | tee -a ${GITHUB_OUTPUT}
       - name: Compute tag prefix
         id: compute-tag-prefix
+        env:
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
           TAG_PREFIX=""
-          if [ "${{ inputs.build_type }}" = "pull-request" ]; then
+          if [ "$BUILD_TYPE" = "pull-request" ]; then
             pr_num="${GITHUB_REF_NAME##*/}"
             BASE_TAG_PREFIX="docker-${pr_num}-"
             NOTEBOOKS_TAG_PREFIX="docker-notebooks-${pr_num}-"
@@ -98,12 +100,14 @@ jobs:
           echo "CUVS_BENCH_CPU_TAG_PREFIX=${CUVS_BENCH_CPU_TAG_PREFIX}" | tee -a ${GITHUB_OUTPUT}
       - name: Compute image repo
         id: compute-image-repo
+        env:
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
           base_repo="base"
           notebooks_repo="notebooks"
           cuvs_bench_repo="cuvs-bench"
           cuvs_bench_cpu_repo="cuvs-bench-cpu"
-          if [ "${{ inputs.build_type }}" = "pull-request" ]; then
+          if [ "$BUILD_TYPE" = "pull-request" ]; then
             base_repo="staging"
             notebooks_repo="staging"
             cuvs_bench_repo="staging"
@@ -129,8 +133,10 @@ jobs:
           echo "ALPHA_TAG=${ALPHA_TAG}" | tee -a ${GITHUB_OUTPUT}
       - name: Compute test matrix
         id: compute-test-matrix
+        env:
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
-          TEST_MATRIX=$(yq '.${{ inputs.build_type }}' matrix-test.yaml)
+          TEST_MATRIX=$(yq ".$BUILD_TYPE" matrix-test.yaml)
           export TEST_MATRIX
 
           echo "TEST_MATRIX=$(yq -n -o json 'env(TEST_MATRIX)' | jq -c '{include: .}')" | tee --append "${GITHUB_OUTPUT}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     needs:
       - check-nightly-ci
       - docker
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main # zizmor: ignore[unpinned-uses]
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -30,9 +30,9 @@ jobs:
     steps:
       - name: Get PR Info
         id: get-pr-info
-        uses: nv-gha-runners/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@main # zizmor: ignore[unpinned-uses]
       - name: Check if nightly CI is passing
-        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
+        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main # zizmor: ignore[unpinned-uses]
         with:
           # default is 7 days, but this repo is downstream of all of RAPIDS so allow a bit longer window
           max-days-without-success: 14

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,4 +53,4 @@ jobs:
     with:
       build_type: pull-request
       run_tests: true
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,9 @@ jobs:
     needs:
       - check-nightly-ci
       - docker
+    permissions:
+      checks: write
+      pull-requests: write
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main # zizmor: ignore[unpinned-uses]
     if: always()
     with:
@@ -40,6 +43,12 @@ jobs:
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
           workflow-id: 'publish.yml'
   docker:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     uses: ./.github/workflows/build-test-publish-images.yml
     with:
       build_type: pull-request

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Update DockerHub README for ${{ matrix.repo_name }}
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,12 @@ concurrency:
 
 jobs:
   docker:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     uses: ./.github/workflows/build-test-publish-images.yml
     with:
       build_type: branch
@@ -30,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
     strategy:
       matrix:
         repo_name:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       build_type: branch
       run_tests: ${{ inputs.run_tests || false }}
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
   readme:
     runs-on: ubuntu-latest
     needs: docker

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,10 @@ jobs:
           - rapidsai/notebooks
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Update DockerHub README for ${{ matrix.repo_name }}
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/release-to-nvstaging.yml
+++ b/.github/workflows/release-to-nvstaging.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute matrix
         id: generate-matrix
@@ -33,16 +33,16 @@ jobs:
       matrix: ${{fromJson(needs.compute-matrix.outputs.matrix)}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
 
       - name: Login to NGC
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: nvcr.io
           username: ${{ secrets.NGC_DOCKER_USER }}

--- a/.github/workflows/release-to-nvstaging.yml
+++ b/.github/workflows/release-to-nvstaging.yml
@@ -53,17 +53,19 @@ jobs:
           password: ${{ secrets.NGC_DOCKER_PASSWORD }}
 
       - name: Release to NGC
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          PYTHON_VER: ${{ matrix.PYTHON_VER }}
+          RAPIDS_VER: ${{ inputs.RAPIDS_VER }}
         run: |
           #!/bin/bash
           set -e
 
-          CUDA_VER=${{ matrix.CUDA_VER }}
           CUDA_MAJOR=${CUDA_VER%%.*}
-          PYTHON_VER=${{ matrix.PYTHON_VER }}
 
           for type in base notebooks; do
-            source="rapidsai/$type:${{ inputs.RAPIDS_VER }}-cuda$CUDA_MAJOR-py$PYTHON_VER"
-            target="nvcr.io/nvstaging/rapids/$type:${{ inputs.RAPIDS_VER }}-cuda$CUDA_MAJOR-py$PYTHON_VER"
+            source="rapidsai/$type:${RAPIDS_VER}-cuda$CUDA_MAJOR-py$PYTHON_VER"
+            target="nvcr.io/nvstaging/rapids/$type:${RAPIDS_VER}-cuda$CUDA_MAJOR-py$PYTHON_VER"
             echo "$source => $target"
             docker run -v ~/.docker/config.json:/config.json quay.io/skopeo/stable:v1.20.0 copy --multi-arch all --dest-authfile=/config.json docker://$source docker://$target
           done

--- a/.github/workflows/release-to-nvstaging.yml
+++ b/.github/workflows/release-to-nvstaging.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Compute matrix
         id: generate-matrix
@@ -34,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/.github/workflows/release-to-nvstaging.yml
+++ b/.github/workflows/release-to-nvstaging.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   compute-matrix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -31,6 +33,8 @@ jobs:
     name: copy (${{ matrix.CUDA_VER }}, ${{ matrix.PYTHON_VER }})
     needs: compute-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix: ${{fromJson(needs.compute-matrix.outputs.matrix)}}
     steps:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -104,5 +104,11 @@ jobs:
           role-duration-seconds: 1800 # 30m
       - name: Upload notebook test outputs
         if: '!cancelled()'
+        env:
+          ARCH: ${{ inputs.ARCH }}
+          CUDA_VER: ${{ inputs.CUDA_VER }}
+          PYTHON_VER: ${{ inputs.PYTHON_VER }}
+          GPU: ${{ inputs.GPU }}
+          DRIVER: ${{ inputs.DRIVER }}
         run: |
-          rapids-upload-to-s3 test_notebooks_output_${{ inputs.ARCH }}_cuda${{ inputs.CUDA_VER }}_py${{ inputs.PYTHON_VER }}_${{ inputs.GPU }}-${{ inputs.DRIVER }}.tar.gz /home/rapids/notebooks_output
+          rapids-upload-to-s3 test_notebooks_output_${ARCH}_cuda${CUDA_VER}_py${PYTHON_VER}_${GPU}-${DRIVER}.tar.gz /home/rapids/notebooks_output

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -75,7 +75,7 @@ jobs:
             curl \
             git
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Install gha-tools
@@ -83,7 +83,7 @@ jobs:
           context/scripts/install-gha-tools
       - name: Get RAPIDS GitHub Info
         id: get-rapids-github-info
-        uses: rapidsai/shared-actions/rapids-github-info@main
+        uses: rapidsai/shared-actions/rapids-github-info@main # zizmor: ignore[unpinned-uses]
       - name: Print environment
         run: |
           rapids-print-env
@@ -95,7 +95,7 @@ jobs:
         if: '!cancelled()'
         run: |
           rapids-conda-retry install -n base awscli
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
         if: '!cancelled()'
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -63,7 +63,7 @@ jobs:
     name: test (${{ matrix.CUDA_VER }}, py${{ matrix.PYTHON_VER }}, ${{ matrix.ARCH }}, ${{ matrix.GPU}}, ${{ matrix.DRIVER }})
     runs-on: "linux-${{ inputs.ARCH }}-gpu-${{ inputs.GPU }}-${{ inputs.DRIVER }}-1"
     container:
-      image: ${{ inputs.NOTEBOOKS_TAG }}
+      image: ${{ inputs.NOTEBOOKS_TAG }} # zizmor: ignore[unpinned-images]
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         RAPIDS_BUILD_TYPE: ${{ inputs.BUILD_TYPE }}

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install gha-tools
         run: |
           context/scripts/install-gha-tools

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -14,7 +14,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
       pull-requests: read
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       sender_login: ${{ github.event.sender.login }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
+    permissions:
+      pull-requests: read
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main # zizmor: ignore[unpinned-uses]
     with:

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -2,7 +2,10 @@
 name: Trigger Breaking Change Notifications
 
 on:
-  pull_request_target:
+  # needs to be pull_request_target so the webhook token is available. no code
+  # gets checked out, only metadata, so there is no risk to executing this from
+  # fork PRs
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - closed
       - reopened

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -13,7 +13,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,16 +64,16 @@ jobs:
     runs-on: "linux-${{ inputs.ARCH }}-cpu4"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.x'
       - name: Install container-canary

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,19 +78,25 @@ jobs:
         with:
           go-version: '1.25.x'
       - name: Install container-canary
+        env:
+          CONTAINER_CANARY_VERSION: ${{ inputs.CONTAINER_CANARY_VERSION }}
         run: |
-          GOBIN=/tmp/canary-bin go install github.com/nvidia/container-canary@${{ inputs.CONTAINER_CANARY_VERSION }}
+          GOBIN=/tmp/canary-bin go install github.com/nvidia/container-canary@${CONTAINER_CANARY_VERSION}
           /tmp/canary-bin/container-canary version
       - name: (base) container-canary checks
+        env:
+          BASE_TAG: ${{ inputs.BASE_TAG }}
         run: |
           export PATH="/tmp/canary-bin:${PATH}"
           ./ci/run-validation-checks.sh \
             --dask-scheduler \
-            ${{ inputs.BASE_TAG }}
+            "${BASE_TAG}"
       - name: (notebooks) container-canary checks
+        env:
+          NOTEBOOKS_TAG: ${{ inputs.NOTEBOOKS_TAG }}
         run: |
           export PATH="/tmp/canary-bin:${PATH}"
           ./ci/run-validation-checks.sh \
             --dask-scheduler \
             --notebooks \
-            ${{ inputs.NOTEBOOKS_TAG }}
+            "${NOTEBOOKS_TAG}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,10 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--severity=warning", "--external-sources"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v1.4.3
     hooks:


### PR DESCRIPTION
## Changes

- all upstream actions are pinned to SHAs (with versions in comments, so renovate still works
- all permissions are explicitly set now, and we don't persist credentials
- all inputs are sanitized -- this is done by moving inputs to env-variables and referencing those
- added zizmor to pre-commit so these fixes stay in place


- **fix(ci): pin all third-party actions and workflows**
- **fix: artipacked credential fixes**
- **fix: remove template injection sites**
- **fix: explicitly request all needed permissions**
- **fix: ignore `secrets-inherit` where we want inherited secrets**
- **fix: ignore `dangerous-triggers` for breaking change alert**
- **fix: mark cache-poisoning warning as a non-issue**
- **feat: add zizmor pre-commit hook**
