### PR TITLE
fix zizmor checks, nightly builds, and update-version.sh

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "actions/*": ref-pin
+        "*": hash-pin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ export LINUX_VER=ubuntu24.04
 export PYTHON_VER=3.14
 
 # RAPIDS version in {major}.{minor}
-export RAPIDS_VER=26.04
+export RAPIDS_VER=26.06
 
 # rapidsai/base
 docker build $(ci/compute-build-args.sh) \

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -100,6 +100,10 @@ sed_runner "s/com\.nvidia\.workbench\.image-version=.*/com.nvidia.workbench.imag
 sed_runner "s|ARG RAPIDS_BRANCH=\"release/[0-9]\+\.[0-9]\+\"|ARG RAPIDS_BRANCH=\"${RAPIDS_BRANCH_NAME}\"|g" Dockerfile
 sed_runner "s|ARG RAPIDS_BRANCH=\"main\"|ARG RAPIDS_BRANCH=\"${RAPIDS_BRANCH_NAME}\"|g" Dockerfile
 
+# docs
+sed_runner "s|RAPIDS_VER=[[:digit:]]\+\.[[:digit:]]|RAPIDS_VER=${NEXT_SHORT_TAG}|g" CONTRIBUTING.md
+sed_runner "s|[[:digit:]]\+\.[[:digit:]]-cuda|${NEXT_SHORT_TAG}-cuda|g" SECURITY.md
+
 # CI files
 for FILE in .github/workflows/*.yaml .github/workflows/*.yml; do
   sed_runner "/shared-workflows/ s|@.*|@${WORKFLOW_BRANCH_REF}|g" "${FILE}"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -119,5 +119,3 @@ sed_runner "s/[[:digit:]]\+\.[[:digit:]]\+a-py/${NEXT_SHORT_TAG}a-py/g" cuvs-ben
 sed_runner "s/[[:digit:]]\+\.[[:digit:]]\+a-cuda/${NEXT_SHORT_TAG}a-cuda/g" cuvs-bench/README.md
 
 sed_runner "s/[[:digit:]]\+\.[[:digit:]]\+a-cuda/${NEXT_SHORT_TAG}a-cuda/g" tests/container-canary/README.md
-
-# TODO: update in README.md too

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 
 ## Usage
 # Primary interface:   bash update-version.sh <new_version> [--run-context=main|release]
@@ -115,3 +115,5 @@ sed_runner "s/[[:digit:]]\+\.[[:digit:]]\+a-py/${NEXT_SHORT_TAG}a-py/g" cuvs-ben
 sed_runner "s/[[:digit:]]\+\.[[:digit:]]\+a-cuda/${NEXT_SHORT_TAG}a-cuda/g" cuvs-bench/README.md
 
 sed_runner "s/[[:digit:]]\+\.[[:digit:]]\+a-cuda/${NEXT_SHORT_TAG}a-cuda/g" tests/container-canary/README.md
+
+# TODO: update in README.md too

--- a/context/scripts/configure-conda-base-environment
+++ b/context/scripts/configure-conda-base-environment
@@ -35,14 +35,12 @@ else
     PYTHON_ABI_TAG="cpython"
 fi
 
-# force-reinstall 'conda' first, to clear out any files
-# left behind from updates
+# force-reinstall 'conda' first, to clear out any files left behind from updates
 rapids-conda-retry install -y -n base --force-reinstall 'conda>=26.5.0'
 
 # update Python in the environment
 rapids-conda-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
 rapids-conda-retry update --all -y -n base
-
 find /opt/conda -follow -type f -name '*.a' -delete
 find /opt/conda -follow -type f -name '*.pyc' -delete
 

--- a/context/scripts/configure-conda-base-environment
+++ b/context/scripts/configure-conda-base-environment
@@ -34,8 +34,15 @@ if [[ "$PYTHON_VERSION_PADDED" > "3.12" ]]; then
 else
     PYTHON_ABI_TAG="cpython"
 fi
+
+# force-reinstall 'conda' first, to clear out any files
+# left behind from updates
+rapids-conda-retry install -y -n base --force-reinstall 'conda>=26.5.0'
+
+# update Python in the environment
 rapids-conda-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
 rapids-conda-retry update --all -y -n base
+
 find /opt/conda -follow -type f -name '*.a' -delete
 find /opt/conda -follow -type f -name '*.pyc' -delete
 


### PR DESCRIPTION
A few things are broken in this repo right now, this fixes them.

## nightly builds

See #878 

Still not sure of the exact cause, but at a step where we use `conda install python` to upgrade/downgrade Python in the `base` environment, all builds where it's different from what was already installed in the `condaforge/miniforge` image fail like this:

```text
Traceback (most recent call last):
  File "/opt/conda/lib/python3.13/site-packages/conda/exception_handler.py", line 30, in __call__
  File "/opt/conda/lib/python3.13/site-packages/conda/cli/main.py", line 53, in main_subshell
  File "/opt/conda/lib/python3.13/site-packages/conda/cli/conda_argparse.py", line 190, in do_call
  File "/opt/conda/lib/python3.13/site-packages/conda/notices/core.py", line 132, in wrapper
  File "/opt/conda/lib/python3.13/site-packages/conda/notices/core.py", line 82, in display_notices
ImportError: cannot import name 'views' from 'conda.notices' (/opt/conda/lib/python3.13/site-packages/conda/notices/__init__.py)
```

I suspect this is due to one of these changes to `conda`'s import structure, maybe https://github.com/conda/conda/pull/15879

Force-reinstalling `conda` before any other operations fixes this.

## zizmor checks

When the `release/26.08` branch was cut, it removed inline comments like `# zizmor: ignore[unpinned-uses]`.

Commit that broke this: https://github.com/rapidsai/docker/commit/935ed5a80dcffd3b9aaa16ce09e22595069d4c29

This causes `pre-commit` to fail on the `release/26.06` branch with a few errors like this:

```text
error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build-test-publish-images.yml:46:11
   |
46 |     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@release/26.06
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
```

This fixes that by moving that configuration into a `zizmor.yml` file, as most other PRs in https://github.com/rapidsai/build-planning/issues/275 did.

## `update-version.sh`

There's one lingering `26.04` reference that was missed when `release/26.06` was cut, and one new `26.06` that would be missed the next time we cut a release branch.

This fixes both of those.
Tested like this:

```shell
ci/release/update-version.sh --run-context=release '26.08.00'
git grep -E '26\.4|26\.04|26\.2|26\.02'
```

## Notes for Reviewers

Running `pre-commit run --all-files` before pushing that release commit would have caught the `zizmor` issue.