### PR TITLE
fix(ci): fix configuration for breaking change notification workflow

### DIFF
--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,24 +1,28 @@
-# Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 name: Trigger Breaking Change Notifications
 
-on:
-  # needs to be pull_request_target so the webhook token is available. no code
-  # gets checked out, only metadata, so there is no risk to executing this from
-  # fork PRs
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+# `zizmor` always flags these triggers because they are easy to use
+# incorrectly. These usages are ok and don't execute any PR-specific
+# code (and so aren't susceptible to exploits from forked PRs)
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types:
       - closed
       - reopened
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main # zizmor: ignore[unpinned-uses]
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
+    secrets:
+      slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/560

Fixes misconfigurations in the GitHub Actions workflow that generates Notifications when PRs are labeled `breaking`.

Any other changes come from making the configuration for this workflow identical across all RAPIDS repos.
