### PR TITLE
feat(renovate): add 7-day cooldown before any updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
   ],
   "packageRules": [
     {
+      "description": "Wait for 7 days post-release before updating",
+      "matchPackageNames": [
+        "*"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "description": "Update most GitHub actions together",
       "groupName": "gh-actions",
       "matchPackageNames": [


### PR DESCRIPTION
Part of rapidsai/build-planning#273

Adds a 7-day cooldown period before renovate proposes any updates