### PR TITLE
Update to CUDA 13.3.0

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,11 +1,11 @@
 # Copyright (c) 2023-2026, NVIDIA CORPORATION.
 
 CUDA_VER:
-# The version format is `<major>.<minor>.<patch>` (e.g. `13.2.0`).
+# The version format is `<major>.<minor>.<patch>` (e.g. `13.3.0`).
 # Use the latest supported minor/patch version for each supported CUDA major
 # version. Only one entry is allowed per CUDA major version.
   - "12.9.1"
-  - "13.2.0"
+  - "13.3.0"
 PYTHON_VER:
   - "3.11"
   - "3.12"


### PR DESCRIPTION
Updates user-facing RAPIDS Docker images to CUDA 13.3.0.

Part of https://github.com/rapidsai/build-planning/issues/286.