### PR TITLE
fix: pin hadolint to 2.14.0

### DIFF
--- a/ci/lint-dockerfiles.sh
+++ b/ci/lint-dockerfiles.sh
@@ -16,7 +16,7 @@ for dockerfile in ${DOCKERFILES}; do
 		--rm \
         -v "$(pwd)/.hadolint.yaml":/.config/hadolint.yaml \
 		-i \
-		hadolint/hadolint \
+		hadolint/hadolint:v2.14.0 \
 	< "${dockerfile}"
 done
 


### PR DESCRIPTION
Upstream released 2.15.0 and it started flagging issues on existing docker images.

We should check and fix those, but not in the middle of a release.  Pinning to 2.14.0 for now.

https://github.com/hadolint/hadolint/releases/


